### PR TITLE
fix: remove redundant hooks field from plugin.json

### DIFF
--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -7,6 +7,5 @@
     "email": "contact@railway.com"
   },
   "repository": "https://github.com/railwayapp/railway-claude-plugin",
-  "license": "MIT",
-  "hooks": "./hooks/hooks.json"
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Removes redundant `hooks` field from plugin.json

## Problem
Claude Code auto-loads `hooks/hooks.json` by convention. The explicit reference causes:
```
Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file
```

## Fix
Remove the `hooks` field from `.claude-plugin/plugin.json`. The field should only reference *additional* hook files beyond the auto-discovered default.

## Testing
Edited cached plugin at `~/.claude/plugins/cache/.../plugin.json` - plugin loads without error, all 12 skills and PreToolUse hook work correctly.