### PR TITLE
Fix environment skill docs: linked service info

### DIFF
--- a/plugins/railway/skills/environment/SKILL.md
+++ b/plugins/railway/skills/environment/SKILL.md
@@ -95,15 +95,21 @@ railway environment <environment-id>
 
 ## Get Context
 
+**JSON output** - project/environment IDs:
 ```bash
 railway status --json
 ```
 
 Extract:
-
 - `project.id` - for service lookup
-- `environment.id` - for the mutations
-- `service.id` - default service if user doesn't specify one
+- `environment.id` - for mutations
+
+**Plain output** - linked service name:
+```bash
+railway status
+```
+
+Shows `Service: <name>` line with the currently linked service. Use the `projectServices` query below to resolve the name to an ID.
 
 ### Resolve Service ID
 


### PR DESCRIPTION
The environment skill incorrectly stated that `railway status --json` returns the linked service ID. It doesn't - only the plain text output shows the linked service name.

- Clarify JSON output gives project/environment IDs only
- Add that plain text output shows linked service name
- Reference existing `projectServices` query to resolve name to ID