### PR TITLE
Add Windows PowerShell support

### DIFF
--- a/plugins/railway/hooks/auto-approve-api.ps1
+++ b/plugins/railway/hooks/auto-approve-api.ps1
@@ -1,0 +1,40 @@
+#!/usr/bin/env pwsh
+# Auto-approve railway-api.ps1 and railway CLI commands on Windows
+
+$inputJson = [Console]::In.ReadToEnd()
+$data = $inputJson | ConvertFrom-Json
+
+$toolName = $data.tool_name
+$command = $data.tool_input.command
+
+if ($toolName -ne "Bash") {
+    exit 0
+}
+
+# Auto-approve railway-api.ps1 calls
+if ($command -match "railway-api\.ps1") {
+    $response = @{
+        hookSpecificOutput = @{
+            hookEventName = "PreToolUse"
+            permissionDecision = "allow"
+            permissionDecisionReason = "Railway API call auto-approved"
+        }
+    }
+    $response | ConvertTo-Json -Compress
+    exit 0
+}
+
+# Auto-approve railway CLI commands (via npx or direct)
+if ($command -match "^(npx\s+railway|railway)\s") {
+    $response = @{
+        hookSpecificOutput = @{
+            hookEventName = "PreToolUse"
+            permissionDecision = "allow"
+            permissionDecisionReason = "Railway CLI command auto-approved"
+        }
+    }
+    $response | ConvertTo-Json -Compress
+    exit 0
+}
+
+exit 0

--- a/plugins/railway/skills/_shared/scripts/railway-api.ps1
+++ b/plugins/railway/skills/_shared/scripts/railway-api.ps1
@@ -1,0 +1,63 @@
+#!/usr/bin/env pwsh
+# Railway GraphQL API helper for Windows PowerShell
+# Usage: ./railway-api.ps1 '<graphql-query>' ['<variables-json>']
+
+$ErrorActionPreference = "Stop"
+
+# Check for jq (optional on Windows, we can use ConvertFrom-Json)
+# For full jq support, install via: winget install jqlang.jq
+
+$ConfigFile = Join-Path $env:USERPROFILE ".railway\config.json"
+
+if (-not (Test-Path $ConfigFile)) {
+    Write-Output '{"error": "Railway config not found. Run: railway login"}'
+    exit 1
+}
+
+try {
+    $config = Get-Content $ConfigFile | ConvertFrom-Json
+    $Token = $config.user.token
+} catch {
+    Write-Output '{"error": "Failed to parse Railway config. Run: railway login"}'
+    exit 1
+}
+
+if ([string]::IsNullOrEmpty($Token) -or $Token -eq "null") {
+    Write-Output '{"error": "No Railway token found. Run: railway login"}'
+    exit 1
+}
+
+if ([string]::IsNullOrEmpty($args[0])) {
+    Write-Output '{"error": "No query provided"}'
+    exit 1
+}
+
+$Query = $args[0]
+$Variables = if ($args[1]) { $args[1] | ConvertFrom-Json } else { $null }
+
+$Payload = @{
+    query = $Query
+}
+
+if ($Variables) {
+    $Payload.variables = $Variables
+}
+
+$Body = $Payload | ConvertTo-Json -Depth 10 -Compress
+
+try {
+    $Response = Invoke-RestMethod `
+        -Uri "https://backboard.railway.com/graphql/v2" `
+        -Method Post `
+        -Headers @{
+            "Authorization" = "Bearer $Token"
+            "Content-Type" = "application/json"
+        } `
+        -Body $Body `
+        -ErrorAction Stop
+    
+    $Response | ConvertTo-Json -Depth 10
+} catch {
+    Write-Output ('{{"error": "{0}"}}' -f $_.Exception.Message.Replace('"', "'"))
+    exit 1
+}


### PR DESCRIPTION
## Changes

- Added railway-api.ps1 - PowerShell version of the GraphQL API helper for Windows users
- Added auto-approve-api.ps1 - PowerShell version of the auto-approve hook for Windows

## Why

The existing scripts are bash-only, which doesn't work natively on Windows. These PowerShell equivalents provide the same functionality for Windows users.

## Testing

- Tested on Windows 11 with PowerShell 7
- Same output format as the bash script
- Handles errors gracefully with JSON error output