### PR TITLE
Add bucket management to Railway skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ References:
 
 | Intent | Reference | Use for |
 |---|---|---|
-| Create or connect resources | `references/setup.md` | Projects, services, databases, templates, workspaces |
+| Create or connect resources | `references/setup.md` | Projects, services, databases, buckets, templates, workspaces |
 | Ship code or manage releases | `references/deploy.md` | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | `references/configure.md` | Environments, variables, config patches, domains, networking |
 | Check health or debug failures | `references/operate.md` | Status, logs, metrics, build/runtime triage, recovery |

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -2,11 +2,11 @@
 name: use-railway
 description: >
   Operate Railway infrastructure: create projects, provision services and
-  databases, deploy code, configure environments and variables, manage domains,
-  troubleshoot failures, check status and metrics, and query Railway docs. Use
-  this skill whenever the user mentions Railway, deployments, services,
-  environments, build failures, or infrastructure operations, even if they don't
-  say "Railway" explicitly.
+  databases, manage object storage buckets, deploy code, configure environments
+  and variables, manage domains, troubleshoot failures, check status and metrics,
+  and query Railway docs. Use this skill whenever the user mentions Railway,
+  deployments, services, environments, buckets, object storage, build failures,
+  or infrastructure operations, even if they don't say "Railway" explicitly.
 allowed-tools: Bash(railway:*), Bash(which:*), Bash(command:*), Bash(npm:*), Bash(npx:*), Bash(curl:*)
 ---
 
@@ -20,6 +20,7 @@ Railway organizes infrastructure in a hierarchy:
 - **Project** is a collection of services under one workspace. It maps to one deployable unit of work.
 - **Environment** is an isolated configuration plane inside a project (for example, `production`, `staging`). Each environment has its own variables, config, and deployment history.
 - **Service** is a single deployable unit inside a project. It can be an app from a repo, a Docker image, or a managed database.
+- **Bucket** is an S3-compatible object storage resource inside a project. Buckets are created at the project level and deployed to environments. Each bucket has credentials (endpoint, access key, secret key) for S3-compatible access.
 - **Deployment** is a point-in-time release of a service in an environment. It has build logs, runtime logs, and a status lifecycle.
 
 Most CLI commands operate on the linked project/environment/service context. Use `railway status --json` to see the context, and `--project`, `--environment`, `--service` flags to override.
@@ -64,6 +65,9 @@ railway variable list --service <svc> --json             # list variables
 railway variable set KEY=value --service <svc>           # set a variable
 railway logs --service <svc> --lines 200 --json          # recent logs
 railway up --detach -m "<summary>"                       # deploy current directory
+railway bucket list --json                               # list buckets in current environment
+railway bucket info --bucket <name> --json               # bucket storage and object count
+railway bucket credentials --bucket <name> --json        # S3-compatible credentials
 ```
 
 ## Routing
@@ -72,7 +76,7 @@ For anything beyond quick operations, load the reference that matches the user's
 
 | Intent | Reference | Use for |
 |---|---|---|
-| Create or connect resources | [setup.md](references/setup.md) | Projects, services, databases, templates, workspaces |
+| Create or connect resources | [setup.md](references/setup.md) | Projects, services, databases, buckets, templates, workspaces |
 | Ship code or manage releases | [deploy.md](references/deploy.md) | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | [configure.md](references/configure.md) | Environments, variables, config patches, domains, networking |
 | Check health or debug failures | [operate.md](references/operate.md) | Status, logs, metrics, build/runtime triage, recovery |
@@ -92,6 +96,7 @@ If the request spans two areas (for example, "deploy and then check if it's heal
 
 Multi-step workflows follow natural chains:
 
+- **Add object storage**: setup (create bucket), setup (get credentials), configure (set S3 variables on app service)
 - **First deploy**: setup (create project + service), configure (set variables and source), deploy, operate (verify healthy)
 - **Fix a failure**: operate (triage logs), configure (fix config/variables), deploy (redeploy), operate (verify recovery)
 - **Add a domain**: configure (add domain + set port), operate (verify DNS and service health)

--- a/plugins/railway/skills/use-railway/references/configure.md
+++ b/plugins/railway/skills/use-railway/references/configure.md
@@ -177,6 +177,8 @@ Natural language mapping: "add replicas in Europe" → `europe-west4-drams3a`, "
 
 **Storage**: `volumeMounts.<volume-id>.mountPath` (string), `volumes.<volume-id>.isDeleted` (boolean)
 
+**Buckets**: `buckets.<bucket-id>.region` (string: `sjc`, `iad`, `ams`, `sin`), `buckets.<bucket-id>.isCreated` (boolean), `buckets.<bucket-id>.isDeleted` (boolean). Buckets are created at the project level via `railway bucket create` and deployed to environments via config patches. The CLI handles this automatically — use `railway bucket` commands
+
 ### Shared variables and project-level config
 
 ```bash

--- a/plugins/railway/skills/use-railway/references/operate.md
+++ b/plugins/railway/skills/use-railway/references/operate.md
@@ -14,6 +14,13 @@ railway deployment list --limit 10 --json                # recent deployments
 
 Deployment statuses: `SUCCESS`, `BUILDING`, `DEPLOYING`, `FAILED`, `CRASHED`, `REMOVED`.
 
+For projects with buckets, include bucket status:
+
+```bash
+railway bucket list --json                                       # buckets in current environment
+railway bucket info --bucket <name> --json                       # storage size, object count, region
+```
+
 If everything looks healthy, return a summary and stop. If something is degraded or failing, continue to log inspection.
 
 ## Logs

--- a/plugins/railway/skills/use-railway/references/setup.md
+++ b/plugins/railway/skills/use-railway/references/setup.md
@@ -131,6 +131,99 @@ railway environment edit --service-config <service> source.image <image:tag>
 
 This sets the service to pull from a container registry instead of building from source.
 
+## Buckets
+
+Buckets are S3-compatible object storage. They are created at the project level and deployed to environments via config patches.
+
+### List buckets
+
+```bash
+railway bucket list --json                                # buckets in current environment
+railway bucket list --environment production --json       # buckets in a specific environment
+```
+
+### Create a bucket
+
+```bash
+railway bucket create my-bucket --region sjc              # create with name and region
+railway bucket create --region iad --json                 # auto-named, JSON output
+```
+
+Available regions:
+
+| Code | Location |
+|---|---|
+| `sjc` | US West (California) |
+| `iad` | US East (Virginia) |
+| `ams` | EU West (Amsterdam) |
+| `sin` | Asia Pacific (Singapore) |
+
+Without `--region`, the CLI prompts interactively. For scripted use, always pass `--region`.
+
+### Delete a bucket
+
+Deletion is permanent and destroys all objects in the bucket.
+
+```bash
+railway bucket delete --bucket my-bucket --yes            # non-interactive
+railway bucket delete --bucket my-bucket --yes --2fa-code 123456   # with 2FA
+```
+
+### Rename a bucket
+
+```bash
+railway bucket rename --bucket my-bucket --name new-name --json
+```
+
+### Bucket info
+
+Check storage usage and object count:
+
+```bash
+railway bucket info --bucket my-bucket --json
+```
+
+Returns storage size (bytes), object count, region, and environment.
+
+### Bucket credentials
+
+Get S3-compatible credentials for connecting your app to a bucket:
+
+```bash
+railway bucket credentials --bucket my-bucket --json
+```
+
+Returns: `endpoint`, `accessKeyId`, `secretAccessKey`, `bucketName`, `region`, `urlStyle`.
+
+Without `--json`, output uses `AWS_*=value` lines suitable for `eval $(railway bucket credentials)` or piping into `.env` files.
+
+To reset credentials (invalidates existing ones):
+
+```bash
+railway bucket credentials --bucket my-bucket --reset --yes
+railway bucket credentials --bucket my-bucket --reset --yes --2fa-code 123456  # with 2FA
+```
+
+### Connect a bucket to a service
+
+After creating a bucket, wire the S3 credentials to your app service as environment variables:
+
+```bash
+# Get credentials
+railway bucket credentials --bucket my-bucket --json
+
+# Set them on your app service
+railway variable set \
+  AWS_ENDPOINT_URL=<endpoint> \
+  AWS_ACCESS_KEY_ID=<access-key> \
+  AWS_SECRET_ACCESS_KEY=<secret-key> \
+  AWS_S3_BUCKET_NAME=<bucket-name> \
+  AWS_DEFAULT_REGION=<region> \
+  --service <app-service>
+```
+
+All subcommands support `--bucket (-b)` and `--environment (-e)` as global flags to skip interactive prompts.
+
 ## Analyze codebase before setup
 
 When setting up a new service from source, detect the project type from marker files:
@@ -192,4 +285,4 @@ When creating projects, Railway uses the default workspace unless `--workspace` 
 ## Validated against
 
 - Docs: [cli.md](https://docs.railway.com/cli), [init.md](https://docs.railway.com/cli/init), [add.md](https://docs.railway.com/cli/add), [link.md](https://docs.railway.com/cli/link), [project.md](https://docs.railway.com/cli/project), [list.md](https://docs.railway.com/cli/list), [whoami.md](https://docs.railway.com/cli/whoami)
-- CLI source: [init.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/init.rs), [add.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/add.rs), [project.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/project.rs), [list.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/list.rs)
+- CLI source: [init.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/init.rs), [add.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/add.rs), [project.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/project.rs), [list.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/list.rs), [bucket.rs](https://github.com/railwayapp/cli/blob/feat/bucket-command/src/commands/bucket.rs)


### PR DESCRIPTION
Document the new `railway bucket` CLI command across skill files:
- SKILL.md: add buckets to resource model, quick ops, routing, and composition
- setup.md: full buckets section (create, list, delete, rename, info, credentials, wiring)
- configure.md: bucket config schema in environment config
- operate.md: bucket status in health snapshot