### PR TITLE
chore: bump plugin version to 1.1.1

### DIFF
--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Railway tools for Claude Code",
   "author": {
     "name": "Railway",


### PR DESCRIPTION
Bumps the plugin version so Claude Code detects and delivers the skill content changes from the previous PR.