### PR TITLE
docs: document railway ssh and clarify that railway run executes locally

### DIFF
--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -92,6 +92,8 @@ railway service status --all --json                      # all services in curre
 railway variable list --service <svc> --json             # list variables
 railway variable set KEY=value --service <svc>           # set a variable
 railway logs --service <svc> --lines 200 --json          # recent logs
+railway ssh --service <svc>                              # interactive shell inside running container
+railway ssh --service <svc> -- <command>                 # run single command inside container
 railway up --detach -m "<summary>"                       # deploy current directory
 railway bucket list --json                               # list buckets in current environment
 railway bucket info --bucket <name> --json               # bucket storage and object count
@@ -120,6 +122,7 @@ If the request spans two areas (for example, "deploy and then check if it's heal
 3. Resolve context before mutation. Know which project, environment, and service you're acting on.
 4. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
 5. After mutations, verify the result with a read-back command.
+6. **`railway run` executes locally, not remotely.** It runs a command in your local shell with the service's environment variables injected. To execute a command inside the remote container, use `railway ssh --service <svc> -- <command>` instead.
 
 ## User-only commands (NEVER execute directly)
 

--- a/plugins/railway/skills/use-railway/references/operate.md
+++ b/plugins/railway/skills/use-railway/references/operate.md
@@ -87,6 +87,35 @@ For database-level metrics and introspection, always use the analysis scripts. S
 - Redis, MySQL, and MongoDB introspection
 - Combined analysis via `scripts/analyze-<type>.py` (postgres, mysql, redis, mongo)
 
+## Shell access
+
+Use `railway ssh` to open an interactive shell or run a one-off command inside a running container:
+
+```bash
+railway ssh --service <service>                          # interactive shell
+railway ssh --service <service> -- <command>             # run a single command and exit
+```
+
+Examples:
+
+```bash
+railway ssh --service api -- env | sort                  # inspect runtime environment
+railway ssh --service worker -- ls -la /app              # inspect filesystem
+railway ssh --service db -- psql -U postgres -c '\l'     # run a DB query inside the container
+```
+
+**`railway run` is not `railway ssh`.** `railway run` executes a command **locally** with the
+service's environment variables injected — it does not run inside the remote container. Use
+`railway ssh` when you need to execute a command inside the container itself.
+
+SSH requires an SSH key registered with Railway:
+
+```bash
+railway ssh keys          # list registered keys
+railway ssh keys add      # register your default local key (~/.ssh/id_*.pub)
+railway ssh keys github   # import keys from GitHub
+```
+
 ## Failure triage
 
 When something is broken, classify the failure first. The fix depends on the class.
@@ -171,5 +200,5 @@ Always verify after fixing. Don't assume the redeploy succeeded.
 
 ## Validated against
 
-- Docs: [status.md](https://docs.railway.com/cli/status), [logs.md](https://docs.railway.com/cli/logs), [observability.md](https://docs.railway.com/observability), [observability/logs.md](https://docs.railway.com/observability/logs), [observability/metrics.md](https://docs.railway.com/observability/metrics)
-- CLI source: [status.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/status.rs), [logs.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/logs.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/deployment.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/redeploy.rs)
+- Docs: [status.md](https://docs.railway.com/cli/status), [logs.md](https://docs.railway.com/cli/logs), [observability.md](https://docs.railway.com/observability), [observability/logs.md](https://docs.railway.com/observability/logs), [observability/metrics.md](https://docs.railway.com/observability/metrics), [ssh.md](https://docs.railway.com/guides/ssh)
+- CLI source: [status.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/status.rs), [logs.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/logs.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/deployment.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/redeploy.rs), [ssh/mod.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/ssh/mod.rs), [ssh/keys.rs](https://github.com/railwayapp/cli/blob/a8a5afe/src/commands/ssh/keys.rs)


### PR DESCRIPTION
## Summary

- Adds a new **Shell access** section to `operate.md` documenting `railway ssh` for interactive shells and one-off commands inside running containers
- Explicitly calls out that **`railway run` is not `railway ssh`** — `railway run` executes locally with injected env vars, not inside the remote container
- Adds `railway ssh` to the common quick operations table in `SKILL.md`
- Adds execution rule #6 to `SKILL.md` warning that `railway run` is local-only
- Updates `Validated against` with SSH docs and CLI source links

## Motivation

Without this documentation, AI agents using this skill naturally reach for `railway run` when asked to execute a command "on" a service, since it's the only relevant command visible. This leads to silently wrong behaviour — the command runs locally, not remotely — and the agent has no way to know it made a mistake.

`railway ssh` is already used extensively in the analysis scripts (`dal.py`, `analyze-*.py`) but is never surfaced in the main skill references where agents would discover it.