### PR TITLE
docs: prefer remote MCP in railway skill guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,16 +29,28 @@ References:
 
 ## Architecture
 
-### CLI first
+### Remote MCP first
 
-Use Railway CLI for context-aware operations.
+When Railway MCP tools are available in the current client, prefer the Railway Remote MCP Server.
+
+- Remote MCP URL: `https://mcp.railway.com`
+- Docs: `https://docs.railway.com/ai/remote-mcp-server`
+- Prefer `railway-agent` for complex or multi-step Railway work.
+- Use direct MCP tools for narrow, single-purpose actions when they exist.
+
+If Railway MCP tools are not available, briefly suggest adding the remote MCP server, then continue with the local fallback path when appropriate.
+
+### CLI fallback
+
+Use Railway CLI for local or unsupported operations.
 
 - Command: `railway`
 - Prefer `--json` output where available.
+- Best for local deploys, repo-aware operations, and workflows that depend on local scripts or SSH-backed analysis.
 
 ### GraphQL API
 
-Use GraphQL for operations the CLI doesn't expose.
+Use GraphQL for operations the CLI doesn't expose, or when the local fallback path needs data the current MCP surface does not provide directly.
 
 - Endpoint: `https://backboard.railway.com/graphql/v2`
 - API helper: `plugins/railway/skills/use-railway/scripts/railway-api.sh`
@@ -65,6 +77,7 @@ When editing this plugin:
 - Keep `SKILL.md` focused on routing, preflight, composition, and common operations.
 - Keep references organized by information type (setup, deploy, configure, operate, api).
 - Keep references action-oriented with reasoning. Explain why, not only what.
+- Keep remote MCP as the preferred execution path, but preserve CLI and scripts as fallback material.
 - Keep CLI behavior claims aligned with Railway docs and CLI source.
 - Keep a single "Validated against" block at the end of each reference.
 - Bump `version` in `plugins/railway/.claude-plugin/plugin.json` in any PR that changes skill content. Claude Code uses this version to detect updates — without a bump, users will not receive changes.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ This repo ships one installable skill:
 
 `use-railway` is route-first. Intent routing is defined in `SKILL.md`, and execution details are split into action-oriented references.
 
+## Execution model
+
+`use-railway` prefers Railway's Remote MCP Server when the current client exposes Railway MCP tools.
+
+- Prefer `railway-agent` for non-trivial Railway tasks.
+- Use direct Railway MCP tools for narrow actions when available.
+- Fall back to the local Railway CLI, GraphQL helper, and analysis scripts for local-only workflows or unsupported MCP cases.
+
+If Railway MCP is not available, the skill now suggests adding `https://mcp.railway.com` before continuing with the local fallback path.
+
 ## Workflow coverage
 
 `use-railway` covers:

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Railway tools for Claude Code",
   "author": {
     "name": "Railway",

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -25,6 +25,23 @@ Railway organizes infrastructure in a hierarchy:
 
 Most CLI commands operate on the linked project/environment/service context. Use `railway status --json` to see the context, and `--project`, `--environment`, `--service` flags to override.
 
+## Tool selection
+
+When Railway MCP tools are available in the current client, prefer the Remote MCP Server over the local CLI.
+
+Execution order:
+
+1. Use `railway-agent` for complex or multi-step Railway work: deployments, debugging, log analysis, service configuration, recovery, and ambiguous operational requests.
+2. Use direct Railway MCP tools for narrow, single-purpose actions when an exact tool exists.
+3. Fall back to the local Railway CLI, `scripts/railway-api.sh`, and the analysis scripts when Railway MCP is unavailable or the task requires local execution.
+
+If Railway MCP tools are not available, briefly suggest adding the Railway remote MCP server before falling back:
+
+- URL: `https://mcp.railway.com`
+- Docs: `https://docs.railway.com/ai/remote-mcp-server`
+
+Keep this suggestion brief and non-blocking. Continue with the CLI or scripts when they can complete the task. Suggest MCP more strongly for complex or investigative requests, since `railway-agent` is the best default entry point for those workflows.
+
 ## Parsing Railway URLs
 
 Users often paste Railway dashboard URLs. Extract IDs before doing anything else:
@@ -52,7 +69,12 @@ Match the environment name (case-insensitive) to get the `environmentId`.
 
 ## Preflight
 
-Before any mutation, verify context:
+Before any mutation, choose the execution path first:
+
+- If Railway MCP tools are available, prefer them and skip CLI install/auth checks unless you later need the fallback path.
+- If Railway MCP tools are not available, suggest adding the remote MCP server and then verify the local CLI path.
+
+For the CLI fallback path, verify context:
 
 ```bash
 command -v railway                # CLI installed
@@ -81,6 +103,8 @@ railway upgrade
 ```
 
 ## Common quick operations
+
+When Railway MCP is available, direct MCP tools or `railway-agent` may be a better fit than these commands. Use the CLI commands below when you need the local fallback path.
 
 These are frequent enough to handle without loading a reference:
 
@@ -115,11 +139,13 @@ If the request spans two areas (for example, "deploy and then check if it's heal
 
 ## Execution rules
 
-1. Prefer Railway CLI. Fall back to `scripts/railway-api.sh` for operations the CLI doesn't expose.
-2. Use `--json` output where available for reliable parsing.
-3. Resolve context before mutation. Know which project, environment, and service you're acting on.
-4. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
-5. After mutations, verify the result with a read-back command.
+1. If Railway MCP tools are available, prefer them over local CLI.
+2. Default to `railway-agent` for complex or multi-step Railway tasks. Use direct MCP tools only when they cleanly match a narrow request.
+3. Fall back to Railway CLI. Fall back to `scripts/railway-api.sh` for operations the CLI doesn't expose.
+4. Use `--json` output where available for reliable parsing.
+5. Resolve context before mutation. Know which project, environment, and service you're acting on.
+6. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
+7. After mutations, verify the result with a read-back command.
 
 ## User-only commands (NEVER execute directly)
 

--- a/plugins/railway/skills/use-railway/references/analyze-db.md
+++ b/plugins/railway/skills/use-railway/references/analyze-db.md
@@ -1,5 +1,7 @@
 # Database Analysis
 
+Use Railway MCP for discovery when it helps you resolve the right project, environment, or service. Keep the local analysis scripts as the primary execution path for deep database introspection and SSH-backed checks.
+
 ## Your Role
 
 You are a database performance expert. The script collects raw data - your job is to **think deeply** about what you see, identify root causes, correlate symptoms, and explain the "why" behind problems.

--- a/plugins/railway/skills/use-railway/references/configure.md
+++ b/plugins/railway/skills/use-railway/references/configure.md
@@ -2,6 +2,8 @@
 
 Manage environments, variables, service config, domains, and networking.
 
+If Railway MCP is available, prefer `railway-agent` for multi-step configuration work. Use the CLI commands below when Railway MCP is unavailable or when you need explicit local fallback behavior.
+
 ## Environments
 
 ### List and switch

--- a/plugins/railway/skills/use-railway/references/deploy.md
+++ b/plugins/railway/skills/use-railway/references/deploy.md
@@ -2,6 +2,8 @@
 
 Ship code, manage releases, and configure builds.
 
+If Railway MCP is available, prefer `railway-agent` for deploy and release workflows that require investigation or multiple coordinated changes. Use the CLI commands below when Railway MCP is unavailable or when the task depends on local source deployment.
+
 ## Deploy code
 
 ### Standard deploy

--- a/plugins/railway/skills/use-railway/references/operate.md
+++ b/plugins/railway/skills/use-railway/references/operate.md
@@ -2,6 +2,8 @@
 
 Check health, read logs, query metrics, and troubleshoot failures.
 
+If Railway MCP is available, prefer `railway-agent` for operational investigations and recovery work. Use the CLI and API commands below when Railway MCP is unavailable or when you need the local fallback path.
+
 ## Health snapshot
 
 Start broad, then narrow:

--- a/plugins/railway/skills/use-railway/references/request.md
+++ b/plugins/railway/skills/use-railway/references/request.md
@@ -2,6 +2,8 @@
 
 Official documentation and community endpoints. GraphQL operations for things the CLI doesn't expose.
 
+If Railway MCP is available, prefer it for operational work and use this reference when you need docs, community evidence, or a local GraphQL fallback the current MCP surface does not cover directly.
+
 ## Official documentation
 
 Primary sources for authoritative Railway information:

--- a/plugins/railway/skills/use-railway/references/setup.md
+++ b/plugins/railway/skills/use-railway/references/setup.md
@@ -2,6 +2,8 @@
 
 Create, link, and organize Railway projects, services, databases, and workspaces.
 
+If Railway MCP is available, prefer `railway-agent` for setup workflows that span multiple steps. Use the CLI commands below when Railway MCP is unavailable or when the task requires the local fallback path.
+
 ## Projects
 
 ### List and discover


### PR DESCRIPTION
## Summary
- update the Railway skill guidance to prefer the remote MCP server when Railway MCP tools are available
- steer complex Railway work toward `railway-agent`, while preserving the existing CLI, GraphQL, and local analysis scripts as fallback paths
- add brief non-blocking guidance to suggest configuring `https://mcp.railway.com` when Railway MCP is missing, and bump the plugin version for skill distribution