### PR TITLE
docs: add MCP routing guidance to Railway skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,18 @@ References:
 
 ## Architecture
 
-### CLI first
+### Tool routing
 
-Use Railway CLI for context-aware operations.
+Use the right Railway operation path for the execution context.
+
+- Remote MCP (`https://mcp.railway.com`) is preferred for agent-native platform operations when configured: account/project/service discovery, deployment status, bounded logs, simple redeploys, simple project creation, and complex workflows through `railway-agent`.
+- Local CLI MCP (`railway mcp`) is preferred when configured and the task benefits from its richer CLI-backed tool surface: variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
+- Railway CLI (`railway`) is preferred for local-machine workflows: current-directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, and exact command output.
+- GraphQL is the fallback for operations that neither MCP nor CLI exposes.
+
+### Railway CLI
+
+Use Railway CLI for context-aware local operations.
 
 - Command: `railway`
 - Prefer `--json` output where available.
@@ -74,3 +83,4 @@ When editing this plugin:
 - https://code.claude.com/docs/en/skills
 - https://code.claude.com/docs/en/plugins
 - https://agentskills.io/specification
+- https://docs.railway.com/ai/remote-mcp-server

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,12 +31,12 @@ References:
 
 ### Tool routing
 
-Use the right Railway operation path for the execution context.
+Choose the Railway operation path that matches the job.
 
-- Remote MCP (`https://mcp.railway.com`) is preferred for agent-native platform operations when configured: account/project/service discovery, deployment status, bounded logs, simple redeploys, simple project creation, and complex workflows through `railway-agent`.
-- Local CLI MCP (`railway mcp`) is preferred when configured and the task benefits from its richer CLI-backed tool surface: variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
-- Railway CLI (`railway`) is preferred for local-machine workflows: current-directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, and exact command output.
-- GraphQL is the fallback for operations that neither MCP nor CLI exposes.
+- Remote MCP (`https://mcp.railway.com`): account/project/service discovery, deployment status, bounded logs, simple redeploys, simple project creation, and complex workflows through `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
+- Local CLI MCP (`railway mcp`): CLI-backed platform operations such as variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
+- Railway CLI (`railway`): local-machine workflows such as current-directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, and exact command output.
+- GraphQL: operations that neither MCP nor CLI exposes.
 
 ### Railway CLI
 

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Railway tools for Claude Code",
   "author": {
     "name": "Railway",

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -27,13 +27,13 @@ Most CLI commands operate on the linked project/environment/service context. Use
 
 ## Tool routing
 
-Railway has three agent-facing operation paths:
+Railway has three agent-facing operation paths. Choose the path that matches the job:
 
-- **Remote MCP** (`https://mcp.railway.com`) is the preferred path when the agent has a Railway MCP server available and the task is a platform operation: account/project/service discovery, deployment state, bounded logs, simple redeploys, simple project creation, or a complex Railway workflow that can be handed to `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
-- **Local CLI MCP** (`railway mcp`) is the preferred MCP path when configured and the task benefits from the richer CLI-backed tool surface: variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
-- **Railway CLI** (`railway`) is the preferred path when the task depends on local machine state: current working directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, or exact command output.
+- **Remote MCP** (`https://mcp.railway.com`): account/project/service discovery, deployment state, bounded logs, simple redeploys, simple project creation, or complex Railway workflows that can be handed to `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
+- **Local CLI MCP** (`railway mcp`): CLI-backed platform operations such as variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
+- **Railway CLI** (`railway`): workflows that depend on local machine state such as current working directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, or exact command output.
 
-If both remote MCP and local CLI MCP are available, prefer remote MCP for OAuth-scoped platform operations that do not need local files or CLI state. Use the local CLI or local CLI MCP when the workflow needs the current repo, local credentials, SSH, database scripts, or a command not exposed by remote MCP.
+If multiple paths are available, choose the one that preserves the needed context. Remote MCP fits OAuth-scoped platform operations that do not need local files or CLI state. Local CLI MCP or the CLI fit workflows that need the current repo, local credentials, SSH, database scripts, or commands not exposed by remote MCP.
 
 Use `scripts/railway-api.sh` only when neither MCP nor CLI exposes the operation, or when a reference gives a specific GraphQL fallback.
 
@@ -72,7 +72,7 @@ railway whoami --json             # authenticated
 railway --version                 # check CLI version
 ```
 
-When Railway MCP is available in the agent, prefer MCP reads before shelling out for equivalent platform state. If using the CLI path, run the CLI checks above.
+When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
 **Context resolution — URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json` — it returns the locally linked project, which is usually unrelated.
@@ -96,7 +96,7 @@ railway upgrade
 
 ## Common quick operations
 
-These are frequent enough to handle without loading a reference. Use equivalent MCP tools when available; otherwise use the CLI:
+These are frequent enough to handle without loading a reference. Use the matching MCP tool when the job is platform-scoped and the tool is available; otherwise use the CLI:
 
 ```bash
 railway status --json                                    # current context
@@ -129,8 +129,8 @@ If the request spans two areas (for example, "deploy and then check if it's heal
 
 ## Execution rules
 
-1. Prefer Railway MCP for agent-native platform operations when it is available.
-2. Prefer the local CLI for workflows that need the current repo, local shell, SSH, database scripts, or unsupported MCP coverage.
+1. Use Railway MCP for platform operations that match an available MCP tool.
+2. Use the local CLI for workflows that need the current repo, local shell, SSH, database scripts, or unsupported MCP coverage.
 3. Fall back to `scripts/railway-api.sh` for operations neither MCP nor CLI exposes.
 4. Use `--json` output where available for reliable parsing.
 5. Resolve context before mutation. Know which project, environment, and service you're acting on.

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -77,6 +77,7 @@ When Railway MCP is available and the job is a platform-state read, use the matc
 **Context resolution — URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json` — it returns the locally linked project, which is usually unrelated.
 - If no URL is given, fall back to `railway status --json` for the linked project/environment/service.
+- When using MCP tools after resolving local context with `railway status --json`, pass the resolved project, environment, and service IDs explicitly. Do not rely on MCP implicit linked context; MCP may not share the CLI's current working directory link.
 
 If the CLI is missing, guide the user to install it.
 

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -25,6 +25,18 @@ Railway organizes infrastructure in a hierarchy:
 
 Most CLI commands operate on the linked project/environment/service context. Use `railway status --json` to see the context, and `--project`, `--environment`, `--service` flags to override.
 
+## Tool routing
+
+Railway has three agent-facing operation paths:
+
+- **Remote MCP** (`https://mcp.railway.com`) is the preferred path when the agent has a Railway MCP server available and the task is a platform operation: account/project/service discovery, deployment state, bounded logs, simple redeploys, simple project creation, or a complex Railway workflow that can be handed to `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
+- **Local CLI MCP** (`railway mcp`) is the preferred MCP path when configured and the task benefits from the richer CLI-backed tool surface: variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
+- **Railway CLI** (`railway`) is the preferred path when the task depends on local machine state: current working directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, or exact command output.
+
+If both remote MCP and local CLI MCP are available, prefer remote MCP for OAuth-scoped platform operations that do not need local files or CLI state. Use the local CLI or local CLI MCP when the workflow needs the current repo, local credentials, SSH, database scripts, or a command not exposed by remote MCP.
+
+Use `scripts/railway-api.sh` only when neither MCP nor CLI exposes the operation, or when a reference gives a specific GraphQL fallback.
+
 ## Parsing Railway URLs
 
 Users often paste Railway dashboard URLs. Extract IDs before doing anything else:
@@ -52,13 +64,15 @@ Match the environment name (case-insensitive) to get the `environmentId`.
 
 ## Preflight
 
-Before any mutation, verify context:
+Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
 railway whoami --json             # authenticated
 railway --version                 # check CLI version
 ```
+
+When Railway MCP is available in the agent, prefer MCP reads before shelling out for equivalent platform state. If using the CLI path, run the CLI checks above.
 
 **Context resolution — URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json` — it returns the locally linked project, which is usually unrelated.
@@ -82,7 +96,7 @@ railway upgrade
 
 ## Common quick operations
 
-These are frequent enough to handle without loading a reference:
+These are frequent enough to handle without loading a reference. Use equivalent MCP tools when available; otherwise use the CLI:
 
 ```bash
 railway status --json                                    # current context
@@ -115,11 +129,13 @@ If the request spans two areas (for example, "deploy and then check if it's heal
 
 ## Execution rules
 
-1. Prefer Railway CLI. Fall back to `scripts/railway-api.sh` for operations the CLI doesn't expose.
-2. Use `--json` output where available for reliable parsing.
-3. Resolve context before mutation. Know which project, environment, and service you're acting on.
-4. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
-5. After mutations, verify the result with a read-back command.
+1. Prefer Railway MCP for agent-native platform operations when it is available.
+2. Prefer the local CLI for workflows that need the current repo, local shell, SSH, database scripts, or unsupported MCP coverage.
+3. Fall back to `scripts/railway-api.sh` for operations neither MCP nor CLI exposes.
+4. Use `--json` output where available for reliable parsing.
+5. Resolve context before mutation. Know which project, environment, and service you're acting on.
+6. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
+7. After mutations, verify the result with a read-back command or MCP read.
 
 ## User-only commands (NEVER execute directly)
 

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -104,6 +104,9 @@ railway status --json                                    # current context
 railway whoami --json                                    # auth and workspace info
 railway project list --json                              # list projects
 railway service status --all --json                      # all services in current context
+railway service list --json                              # services in current env (verify before retrying `add`)
+railway add --database <type> --json                     # add one database; ALWAYS pass --json
+railway add --service <name> --json                      # add empty service; ALWAYS pass --json
 railway variable list --service <svc> --json             # list variables
 railway variable set KEY=value --service <svc>           # set a variable
 railway logs --service <svc> --lines 200 --json          # recent logs

--- a/plugins/railway/skills/use-railway/references/setup.md
+++ b/plugins/railway/skills/use-railway/references/setup.md
@@ -58,12 +58,18 @@ scripts/railway-api.sh \
 ### Create a service
 
 ```bash
-railway add --service <service-name>          # empty service
-railway add --database postgres               # managed database (postgres, redis, mysql, mongodb)
-railway add                                   # interactive, prompts for type
+railway add --service <name> --json           # empty service
+railway add --database postgres --json        # managed database (postgres, redis, mysql, mongo)
+railway add                                   # interactive only — do not use non-interactively
 ```
 
-Before adding a database, check for existing database services to avoid duplicates. Run `railway environment config --json` and inspect `source.image` for each service:
+**Always pass `--json` to `railway add`.** Without it, a successful database create writes nothing to stdout — only a `> What do you need? Database` echo on stderr that looks identical to a stalled interactive prompt. Retrying based on "no stdout came back" silently provisions a second database. With `--json`, success prints `{"serviceId":"…","serviceName":"…"}` and failure exits non-zero.
+
+**`--database` is cumulative, not last-wins.** `railway add --database postgres --database redis` creates *both* in a single call. Don't repeat the flag — issue one `railway add` per database.
+
+**If `railway add` output looks ambiguous, never retry blind.** Run `railway service list --json` (or query `project.services` via [request.md](request.md)) first and compare against what you expected to exist. Treat the service list as the source of truth, not the CLI's stdout shape.
+
+Before adding a database — and before retrying any `railway add` whose output you can't interpret — list existing services to avoid duplicates. Run `railway service list --json` for a fast count, or `railway environment config --json` and inspect `source.image` per service when you need to identify the engine:
 
 | Image pattern | Database |
 |---|---|


### PR DESCRIPTION
## Summary
- add MCP-aware tool routing to the Railway skill
- distinguish remote MCP, local CLI MCP, local CLI, and GraphQL fallback paths
- update authoring guidance and bump the Claude plugin version

## Notes
This keeps the skill as the operating playbook while making MCP the preferred agent interface when available. The CLI remains preferred for local repo, SSH, database analysis, linking, and unsupported MCP workflows.

## Validation
- git diff --check