### PR TITLE
docs: propagate Railway skill telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Use Railway CLI for context-aware local operations.
 
 - Command: `railway`
 - Prefer `--json` output where available.
+- Skill telemetry: set `RAILWAY_CALLER=skill:use-railway@<plugin-version>` and a stable `RAILWAY_AGENT_SESSION` before Railway CLI calls made from the skill.
 
 ### GraphQL API
 
@@ -51,6 +52,7 @@ Use GraphQL for operations the CLI doesn't expose.
 
 - Endpoint: `https://backboard.railway.com/graphql/v2`
 - API helper: `plugins/railway/skills/use-railway/scripts/railway-api.sh`
+- The API helper attaches `X-Railway-Skill-Id`, `X-Railway-Skill-Version`, and `X-Railway-Agent-Session` headers.
 
 ### API token
 

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Railway tools for Claude Code",
   "author": {
     "name": "Railway",

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -67,12 +67,16 @@ Match the environment name (case-insensitive) to get the `environmentId`.
 Before any mutation, verify the tool path and context:
 
 ```bash
+export RAILWAY_CALLER="${RAILWAY_CALLER:-skill:use-railway@1.1.3}"
+export RAILWAY_AGENT_SESSION="${RAILWAY_AGENT_SESSION:-railway-skill-$(date +%s)-$$}"
 command -v railway                # CLI installed
 railway whoami --json             # authenticated
 railway --version                 # check CLI version
 ```
 
 When Railway MCP is available in the agent, prefer MCP reads before shelling out for equivalent platform state. If using the CLI path, run the CLI checks above.
+
+Keep `RAILWAY_CALLER` and `RAILWAY_AGENT_SESSION` exported for Railway CLI calls made while this skill is active. They let Railway correlate skill-assisted CLI actions without adding a separate analytics client to the skill.
 
 **Context resolution — URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json` — it returns the locally linked project, which is usually unrelated.

--- a/plugins/railway/skills/use-railway/scripts/railway-api.sh
+++ b/plugins/railway/skills/use-railway/scripts/railway-api.sh
@@ -4,6 +4,12 @@
 
 set -e
 
+SKILL_ID="use-railway"
+SKILL_VERSION="${RAILWAY_SKILL_VERSION:-1.1.3}"
+
+export RAILWAY_CALLER="${RAILWAY_CALLER:-skill:${SKILL_ID}@${SKILL_VERSION}}"
+export RAILWAY_AGENT_SESSION="${RAILWAY_AGENT_SESSION:-railway-skill-$(date +%s)-$$}"
+
 if ! command -v jq &>/dev/null; then
   echo '{"error": "jq not installed. Install with: brew install jq"}'
   exit 1
@@ -35,7 +41,12 @@ else
   PAYLOAD=$(jq -n --arg q "$1" '{query: $q}')
 fi
 
-curl -s https://backboard.railway.com/graphql/v2 \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "$PAYLOAD"
+HEADERS=(
+  -H "Authorization: Bearer $TOKEN"
+  -H "Content-Type: application/json"
+  -H "X-Railway-Skill-Id: $SKILL_ID"
+  -H "X-Railway-Skill-Version: $SKILL_VERSION"
+  -H "X-Railway-Agent-Session: $RAILWAY_AGENT_SESSION"
+)
+
+curl -s https://backboard.railway.com/graphql/v2 "${HEADERS[@]}" -d "$PAYLOAD"


### PR DESCRIPTION
## Summary
- Add Railway skill telemetry context to CLI guidance via `RAILWAY_CALLER` and `RAILWAY_AGENT_SESSION`.
- Attach skill ID, version, and agent session headers in the GraphQL helper.
- Bump the Claude plugin version so users receive the skill update.

## Test
- `bash -n plugins/railway/skills/use-railway/scripts/railway-api.sh`