### PR TITLE
use-railway: stop agents passing --browserless on desktops (v1.2.5)

### DIFF
--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using the Railway CLI and local MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -93,7 +93,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.2.4" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.2.5" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -101,7 +101,7 @@ railway --version                 # check CLI version
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.2.4` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.2.5` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.
@@ -146,11 +146,15 @@ Related: `railway up --new` creates a *fresh* project + service from the current
 
 **Headless / no browser:**
 
+The CLI **auto-detects** SSH sessions, CI, and a missing `DISPLAY` and switches to the device-code flow on its own — you almost never need to force it.
+
+**Do NOT pass `--browserless` just because you are an agent or your shell is non-interactive.** If the human is at this machine (a local IDE or desktop session — the common case), bare `railway login` opens *their* browser directly, which completes far more reliably than relaying a device code (~90% vs ~60% success for agent-driven sign-ins). Being a coding agent does not make the machine headless.
+
 ```bash
-railway login --browserless
+railway login --browserless   # ONLY for machines with genuinely no browser
 ```
 
-Prints a verification URL and a short user code (RFC 8628 device-code flow). The user opens the URL on any device and enters the code. The CLI auto-detects SSH sessions, CI, and a missing `DISPLAY` and falls back to device-code flow automatically when a browser can't open.
+Forces the device-code flow (RFC 8628): prints a sign-in link and a short code for the user to open on any device. Reserve it for machines where no browser exists — SSH boxes, containers, remote VMs the auto-detection missed. When you do end up in a device-code flow, follow the relay procedure above: surface the sign-in link to the user the moment it prints.
 
 **Agent harness, human present**: when the CLI detects an agent harness (Claude Code, Cursor, Codex, …) with a human at the keyboard, `railway up` opens the browser and skips the confirm prompt — the agent invocation is treated as consent. A real human still has to complete OAuth in the browser.
 

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -154,7 +154,7 @@ The CLI **auto-detects** SSH sessions, CI, and a missing `DISPLAY` and switches 
 railway login --browserless   # ONLY for machines with genuinely no browser
 ```
 
-Forces the device-code flow (RFC 8628): prints a sign-in link and a short code for the user to open on any device. Reserve it for machines where no browser exists — SSH boxes, containers, remote VMs the auto-detection missed. When you do end up in a device-code flow, follow the relay procedure above: surface the sign-in link to the user the moment it prints.
+Forces the device-code flow (RFC 8628): prints a sign-in link and a short code for the user to open on any device. Reserve it for machines where no browser exists — SSH boxes, containers, remote VMs the auto-detection missed. When you do end up in a device-code flow, follow the relay procedure below: surface the sign-in link to the user the moment it prints.
 
 **Agent harness, human present**: when the CLI detects an agent harness (Claude Code, Cursor, Codex, …) with a human at the keyboard, `railway up` opens the browser and skips the confirm prompt — the agent invocation is treated as consent. A real human still has to complete OAuth in the browser.
 
@@ -164,7 +164,7 @@ When the CLI can't open a browser (sandboxed shell, container, SSH, no `DISPLAY`
 
 1. **Preferred — background execution** (e.g. Claude Code: `run_in_background`, then poll with `BashOutput`):
    - Start the command in the background.
-   - Poll its output. The instant a `Sign in at: <url>` / `Enter this code: <code>` block appears, **stop everything and relay the URL and code to the user verbatim** — do not summarize, shorten, or defer them. Tell the user to open the link now and enter the code.
+   - Poll its output. The instant a sign-in block appears (`Sign in with one click: <url>` on newer CLIs, or `Sign in at: <url>` / `Enter this code: <code>` on older ones), **stop everything and relay it to the user verbatim** — do not summarize, shorten, or defer it. Prefer the one-click URL when present; otherwise relay the URL and code together. Tell the user to open the link now.
    - Leave the command running and keep polling. When the user completes sign-in, the same process picks up the session and continues into the deploy on its own. Then verify per the deploy rules below.
 2. **No background support — set expectations, use the longest timeout:**
    - Before running, tell the user: *"This will print a sign-in link — I'll show it to you the moment I have it. Please complete it promptly; the code expires in 10 minutes."*

--- a/plugins/railway/skills/use-railway/references/setup.md
+++ b/plugins/railway/skills/use-railway/references/setup.md
@@ -12,7 +12,7 @@ A brand-new user with no Railway account is onboarded through the same unified O
 
 `railway up` and `railway login` self-validate auth — don't run `railway whoami` before them.
 
-**Headless / SSH / CI**: `railway login --browserless` prints a verification URL + short device code (RFC 8628). The CLI also auto-falls-back to this when a browser can't open.
+**Headless / SSH / CI**: the CLI auto-detects these and switches to the device-code flow (RFC 8628: sign-in link + short code) on its own. Do NOT pass `--browserless` just because you are an agent — if the human is at this machine, bare `railway login` opens their browser and completes far more reliably. Reserve the flag for machines with genuinely no browser that the auto-detection missed.
 
 **`railway up --json` / `--ci` do NOT auto-prompt** an unauthed user. `--json` emits a structured `{"error":"Not signed in.","code":"NOT_AUTHENTICATED", ...}` on stdout and exits non-zero — detect `NOT_AUTHENTICATED`, run `railway login`, then retry.
 


### PR DESCRIPTION
## Change

Rewrite the section to invert the framing:

- Lead with the CLI's **auto-detection** (SSH/CI/no-DISPLAY) — the flag is almost never needed
- Explicit instruction: **being a coding agent does not make the machine headless** — if the human is at this machine, bare `railway login` opens *their* browser and completes far more reliably (~90% vs ~60%)
- `--browserless` annotated as "ONLY for machines with genuinely no browser" (SSH boxes, containers, remote VMs)
- Cross-links the v1.2.4 relay procedure for flows where device-code is genuinely unavoidable

## Measurability

Version **1.2.4 → 1.2.5** in all three plugin manifests and both `RAILWAY_CALLER` strings. Paired with CLI-side `transport_reason` telemetry (railwayapp/cli#960, backend railwayapp/mono#30991), the success metric is defined up front: **`transport_reason='flag_browserless'` share of desktop agent auths**. If it falls for `@1.2.5` callers, the wording worked; if not, we've proven prose can't beat agent priors — with data, not another hypothesis.

Early v1.2.4 signal suggests skill wording does move agent behavior: skill-driven device-code success is running ~80% vs the ~59% bare-claude_code baseline.

## Related

- railwayapp/mono#30991 — backend accepts `transportReason` (merge first)
- railwayapp/cli#960 — CLI sends it + fallback relabel + CI-truthiness fix + one-click activation link
- Follow-up to #48 (v1.2.4 relay procedure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)