### PR TITLE
use-railway: skill-freshness preflight + sandbox support (v1.2.6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ References:
 | Ship code or manage releases | `references/deploy.md` | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | `references/configure.md` | Environments, variables, config patches, domains, networking |
 | Check health or debug failures | `references/operate.md` | Status, logs, metrics, build/runtime triage, recovery |
+| Use a sandbox or build remotely | `references/sandbox.md` | Sandboxes: create/fork, remote exec, remote template builds, port forwarding (requires Priority Boarding) |
 | Analyze databases | `references/analyze-db.md` | Database introspection and performance analysis, then DB-specific refs |
 | Request from API, docs, or community | `references/request.md` | GraphQL mutations, metrics queries, Central Station, official docs |
 

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using the Railway CLI and local MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -93,15 +93,31 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.2.5" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.2.6" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
 **Exception**: `railway up` and `railway login` self-validate auth and run their own unauth-aware flows. Don't run `railway whoami` before them — it adds a redundant failing call without changing what you do next. See [Account creation & sign-in](#account-creation--sign-in).
 
+### Skill freshness
+
+Once per session, alongside the preflight checks, verify the installed Railway agent tooling is current. Root help ends with an `Agent tooling:` health section (printed to stderr, CLI 5.9+; older CLIs print nothing — skip this check rather than retrying):
+
+```bash
+railway --help 2>&1 | grep -A4 "Agent tooling:"
+```
+
+Act on what it reports:
+
+- Skills installed and up to date — continue; nothing to do.
+- An update is available (`rev <a> → <b> available`) — run `railway skills update`, then tell the user to restart their coding tool so the updated skills load. This session keeps running on the old skill revision until restart: finish the current request, and if this skill's guidance disagrees with the updated CLI's own output, trust the CLI.
+- Skills or MCP server missing (`✗` lines) — run `railway setup agent -y`, then tell the user to restart their coding tool.
+
+Check once per session and don't re-run it after acting; the restart prompt to the user is the resolution, not another check.
+
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.2.5` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.2.6` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -84,6 +84,9 @@ Route by user intent *before* running preflight checks. The preflight ceremony b
 - **Only when there is nothing to deploy** — an empty / non-app directory, or the user explicitly says they just want an account with no deploy — use `railway login` (creates new accounts on the fly through the same OAuth surface). There is no separate signup command.
 - Signup is the flow most likely to hit the device-code wait (brand-new users in sandboxed/headless agent environments). Follow [Device-code sign-in: relay the link immediately](#account-creation--sign-in) — a signup lost to an expired code is a lost user, not a retry.
 
+**Sandbox / remote-build intent** ("give me a sandbox", "spin up a scratch environment", "build this remotely", "run this remotely"):
+- Load [sandbox.md](references/sandbox.md) and follow it. Sandboxes require the feature to be enabled in Priority Boarding — if a sandbox command fails with a feature-availability error, prompt the user to enable Sandboxes in Priority Boarding rather than retrying.
+
 **Other intents** (querying state, listing projects, configuring variables, debugging failures):
 - Follow the Preflight section below.
 
@@ -272,6 +275,7 @@ For anything beyond quick operations, load the reference that matches the user's
 | Ship code or manage releases | [deploy.md](references/deploy.md) | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | [configure.md](references/configure.md) | Environments, variables, config patches, domains, networking |
 | Check health or debug failures | [operate.md](references/operate.md) | Status, logs, metrics, build/runtime triage, recovery |
+| Use a sandbox or build remotely ("sandbox", "scratch environment", "ephemeral box", "build remotely", "remote build", "run this remotely") | [sandbox.md](references/sandbox.md) | Create/fork sandboxes, run commands remotely, remote template builds, port forwarding, teardown. Requires Sandboxes enabled in Priority Boarding — if unavailable, prompt the user to enable it. |
 | Request from API, docs, or community | [request.md](references/request.md) | Railway GraphQL API queries/mutations, metrics queries, Central Station, official docs |
 
 If the request spans two areas (for example, "deploy and then check if it's healthy"), load both references and compose one response.

--- a/plugins/railway/skills/use-railway/references/sandbox.md
+++ b/plugins/railway/skills/use-railway/references/sandbox.md
@@ -1,0 +1,125 @@
+# Sandboxes
+
+Sandboxes are ephemeral remote Linux environments attached to a Railway project + environment. Use them when the user asks for a sandbox, a scratch/ephemeral environment, or wants to build or run something remotely without touching deployed services. Sandboxes link at the project level — a linked project and environment (or explicit `--project` / `--environment` flags) is enough; no service link is needed.
+
+## Availability — Priority Boarding required
+
+**Sandboxes must be enabled in Priority Boarding.** If sandbox commands fail with a feature-availability error from the API (the `PROJECT_SANDBOXES` feature is not enabled for the workspace), do not retry — prompt the user to enable Sandboxes through Priority Boarding in the Railway dashboard, then resume once they confirm.
+
+Two non-errors to expect:
+
+- Every sandbox command prints `Warning: Railway sandboxes are experimental and APIs may change or break during testing.` on stderr. This is informational — not a failure.
+- Context errors (`No project selected...` / `No environment selected...`) mean missing linking, not missing access: run `railway link` or pass `--project` and `--environment`.
+
+## Create and connect
+
+### Create a sandbox
+
+```bash
+railway sandbox create
+railway sandbox create --variable DB_URL=postgres.DATABASE_URL --env-file .env
+railway sandbox create --private-network --idle-timeout-minutes 60 --json
+```
+
+`create` boots a sandbox and remembers it as the **active sandbox** — later commands that take `--id` default to it. `--variable` values may reference other Railway variables (`postgres.DATABASE_URL` or the full `${{postgres.DATABASE_URL}}` form), resolved server-side at create time; `--variable` overrides `--env-file` entries with the same key. Sandboxes are isolated with public egress by default — pass `--private-network` when the sandbox must reach internal hosts like `postgres.railway.internal`. `--idle-timeout-minutes` auto-destroys the sandbox after that long idle; attached sessions send a heartbeat that keeps it alive. Prefer `--json` for parsing the created id.
+
+### Connect over SSH
+
+```bash
+railway sandbox ssh                      # interactive shell in the active sandbox
+railway sandbox ssh --id <sandbox-id> -- ls -la
+```
+
+Trailing `-- <command>` runs a single command instead of an interactive shell. `--session <name>` resumes a durable session by name.
+
+## Run commands remotely
+
+### One-off commands
+
+```bash
+railway sandbox exec -- npm test
+railway sandbox exec --id <sandbox-id> --timeout 120 -- ./integration.sh
+```
+
+Everything after `--` is the command. A single argument runs as a shell command; multiple arguments run as argv with quoting preserved. `--timeout <seconds>` is a client-side deadline — on expiry the command is terminated and the CLI exits 124 (GNU timeout convention), so treat exit 124 as "took too long", not "failed".
+
+### Long-running commands — detach and reattach
+
+```bash
+railway sandbox exec --detach -- npm run build   # prints a durable session name, exits
+railway sandbox exec --session <name>            # reattach and stream the output
+```
+
+`--detach` starts the command, prints its durable session name to stdout, and returns while the command keeps running — use it for builds or jobs longer than you want to block on. Reattach with `--session <name>`; add `--resume-from-last-read` to skip replaying retained scrollback. Durable sessions are not available on every sandbox — when the CLI warns `durable sessions are unavailable for this sandbox; ran attached`, the command still ran, just without reattach support.
+
+## Remote builds
+
+Use templates to run build steps remotely. Build steps execute server-side in a transient sandbox; the result is a content-addressed filesystem snapshot cached server-side (~7 days), so re-running the same recipe is an instant cache hit.
+
+### Build remotely
+
+```bash
+railway sandbox template build --name ci -c 'npm ci' -c 'npm run build' --wait
+```
+
+`-c` is repeatable and runs in order; each step must exit 0 within 10 minutes. `--wait` polls until READY or FAILED. `--name` is a local-only handle for reuse.
+
+### Boot from the build
+
+```bash
+railway sandbox create --template ci             # boots from the cached snapshot
+railway sandbox exec -- npm start
+```
+
+Template recipes are stored locally by this CLI — `Unknown template` means it was built elsewhere or never built; rebuild it with the command the error message prints.
+
+### Inspect templates
+
+```bash
+railway sandbox template status <id-or-name> --json
+railway sandbox template list --json
+```
+
+## Port forwarding
+
+```bash
+railway sandbox forward 3000              # localhost:3000 → sandbox port 3000
+railway sandbox forward 8080:3000 5432    # explicit local port; multiple ports per connection
+```
+
+If a requested local port is busy the CLI picks a nearby free one and says so — pass `--strict` to fail instead. The tunnel auto-reconnects with backoff if the relay drops while the sandbox is still running.
+
+## Fork a sandbox
+
+```bash
+railway sandbox fork                      # fork the active sandbox; the fork becomes active
+railway sandbox fork <sandbox-id> --variable FOO=bar --private-network
+```
+
+A fork copies the source's filesystem state but **does not inherit its variables or network mode** — re-pass `--variable`/`--env-file`/`--private-network` as needed.
+
+## List and teardown
+
+```bash
+railway sandbox list --json               # also refreshes the local id cache
+railway sandbox list --all                # include destroyed sandboxes
+railway sandbox destroy                   # destroy the active sandbox
+railway sandbox destroy <sandbox-id>
+```
+
+Destroy sandboxes you created for a task once the task is done — idle timeout is the backstop, not the cleanup plan.
+
+## Troubleshoot sandboxes
+
+- **Feature-availability error from the API**: Sandboxes aren't enabled for this workspace. Prompt the user to enable Sandboxes through Priority Boarding in the Railway dashboard; don't retry until they confirm.
+- **`No project selected` / `No environment selected`**: run `railway link` or pass `--project` with `--environment`.
+- **`Unknown template ...`**: the recipe isn't in this CLI's local store — rebuild with `railway sandbox template build --name <name> -c '<command>' --wait`.
+- **`Template build failed`**: a step exited non-zero or exceeded its 10-minute limit; fix that step and rebuild.
+- **Exit code 124 from `exec`**: the client-side `--timeout` expired — rerun with a larger timeout or `--detach`.
+- **`that session may have expired; the server started a fresh one instead`**: the durable session lapsed; the command ran in a new session — check whether prior state mattered.
+- **SSH/forward drops**: the CLI reconnects automatically while the sandbox is RUNNING; if it reports the sandbox STOPPED, create or fork a new one.
+
+## Validated against
+
+- Docs: [sandboxes.md](https://docs.railway.com/sandboxes), [sandbox.md](https://docs.railway.com/cli/sandbox)
+- CLI source: [sandbox.rs](https://github.com/railwayapp/cli/blob/v5.8.0/src/commands/sandbox.rs), [sandbox_exec.rs](https://github.com/railwayapp/cli/blob/v5.8.0/src/controllers/sandbox_exec.rs)


### PR DESCRIPTION
## What

Two additions to `use-railway`, shipped under one version bump (1.2.5 → 1.2.6).

### 1. Skill-freshness check in preflight

CLI 5.9 root help now ends with an `Agent tooling:` health section showing skills install state, the installed revision, and whether upstream has moved (railwayapp/cli#961). The skill now reads it once per session during preflight:

```bash
railway --help 2>&1 | grep -A4 "Agent tooling:"
```

- **Up to date** → continue.
- **Update available** (`rev <a> → <b> available`) → run `railway skills update`, then **prompt the user to restart their coding tool**. The running session keeps the old skill revision until restart, so the agent is told to finish the current request and trust the CLI's own output over the skill text on disagreement.
- **Skills/MCP missing** → `railway setup agent -y`, same restart prompt.

Older CLIs print no section — the skill skips the check rather than retrying. Scoped to Preflight so the deploy/signup fast paths stay friction-free. One pass per session; the restart prompt is the resolution, not another check.

### 2. Sandbox support (`references/sandbox.md`)

New reference mirroring the deploy/setup structure, covering the full `railway sandbox` surface: create + connect (active sandbox, `--variable` references like `postgres.DATABASE_URL`, `--private-network`, idle timeout + heartbeat), remote exec (`--` semantics, `--timeout`/exit-124 convention, `--detach` + durable-session reattach), **remote builds** via content-addressed templates (~7-day server cache, 10-min-per-step limit, the local-recipe `Unknown template` gotcha), port forwarding with reconnect behavior, fork (no variable/network inheritance), list/teardown, and a Troubleshoot section keyed to the CLI's actual error strings.

**Routing:** fires when the user requests a sandbox or wants to build/run remotely — a SKILL.md intent-table row with trigger phrases plus a fast-path entry in the intent-based routing section. AGENTS.md reference table updated to match.

**Priority Boarding gate, called out at three layers** (routing table, intent entry, and a dedicated Availability section at the top of the reference): Sandboxes must be enabled in Priority Boarding; on a feature-availability error the agent prompts the user to enable Sandboxes rather than retrying. The reference also teaches that the experimental stderr warning on every sandbox command is informational, not a failure, and that `No project/environment selected` is a linking problem, not an access problem.

## Version sync (1.2.6)

All five locations bumped together: the three plugin manifests (claude/codex/cursor) and both `RAILWAY_CALLER=skill:use-railway@<version>` telemetry literals in SKILL.md.

## Validated against

- `Agent tooling:` output format verified against the merged CLI implementation (railwayapp/cli#961).
- Sandbox commands, flags, defaults, and error strings sourced from CLI `src/commands/sandbox.rs` @ v5.8.0; docs links (`docs.railway.com/sandboxes`, `/cli/sandbox`) verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)