### PR TITLE
use-railway: sandbox checkpoints — capture, boot, manage (v1.3.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ References:
 | Ship code or manage releases | `references/deploy.md` | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | `references/configure.md` | Environments, variables, config patches, domains, networking |
 | Check health or debug failures | `references/operate.md` | Status, logs, metrics, build/runtime triage, recovery |
-| Use a sandbox or build remotely | `references/sandbox.md` | Sandboxes: create/fork, remote exec, remote template builds, port forwarding (requires Priority Boarding) |
+| Use a sandbox or build remotely | `references/sandbox.md` | Sandboxes: create/fork, remote exec, remote template builds, checkpoints, port forwarding (requires Priority Boarding) |
 | Analyze databases | `references/analyze-db.md` | Database introspection and performance analysis, then DB-specific refs |
 | Request from API, docs, or community | `references/request.md` | GraphQL mutations, metrics queries, Central Station, official docs |
 

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using the Railway CLI and local MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -84,7 +84,7 @@ Route by user intent *before* running preflight checks. The preflight ceremony b
 - **Only when there is nothing to deploy** — an empty / non-app directory, or the user explicitly says they just want an account with no deploy — use `railway login` (creates new accounts on the fly through the same OAuth surface). There is no separate signup command.
 - Signup is the flow most likely to hit the device-code wait (brand-new users in sandboxed/headless agent environments). Follow [Device-code sign-in: relay the link immediately](#account-creation--sign-in) — a signup lost to an expired code is a lost user, not a retry.
 
-**Sandbox / remote-build intent** ("give me a sandbox", "spin up a scratch environment", "build this remotely", "run this remotely"):
+**Sandbox / remote-build intent** ("give me a sandbox", "spin up a scratch environment", "build this remotely", "run this remotely", "checkpoint/snapshot the sandbox", "save this sandbox state", "restore my sandbox"):
 - Load [sandbox.md](references/sandbox.md) and follow it. Sandboxes require the feature to be enabled in Priority Boarding — if a sandbox command fails with a feature-availability error, prompt the user to enable Sandboxes in Priority Boarding rather than retrying.
 
 **Other intents** (querying state, listing projects, configuring variables, debugging failures):
@@ -96,7 +96,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.2.6" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.0" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -120,7 +120,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.2.6` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.0` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.
@@ -275,7 +275,7 @@ For anything beyond quick operations, load the reference that matches the user's
 | Ship code or manage releases | [deploy.md](references/deploy.md) | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | [configure.md](references/configure.md) | Environments, variables, config patches, domains, networking |
 | Check health or debug failures | [operate.md](references/operate.md) | Status, logs, metrics, build/runtime triage, recovery |
-| Use a sandbox or build remotely ("sandbox", "scratch environment", "ephemeral box", "build remotely", "remote build", "run this remotely") | [sandbox.md](references/sandbox.md) | Create/fork sandboxes, run commands remotely, remote template builds, port forwarding, teardown. Requires Sandboxes enabled in Priority Boarding — if unavailable, prompt the user to enable it. |
+| Use a sandbox or build remotely ("sandbox", "scratch environment", "ephemeral box", "build remotely", "remote build", "run this remotely", "checkpoint", "snapshot/save/restore sandbox state") | [sandbox.md](references/sandbox.md) | Create/fork sandboxes, run commands remotely, remote template builds, checkpoints (save/restore sandbox state), port forwarding, teardown. Requires Sandboxes enabled in Priority Boarding — if unavailable, prompt the user to enable it. |
 | Request from API, docs, or community | [request.md](references/request.md) | Railway GraphQL API queries/mutations, metrics queries, Central Station, official docs |
 
 If the request spans two areas (for example, "deploy and then check if it's healthy"), load both references and compose one response.

--- a/plugins/railway/skills/use-railway/references/sandbox.md
+++ b/plugins/railway/skills/use-railway/references/sandbox.md
@@ -54,7 +54,7 @@ railway sandbox exec --session <name>            # reattach and stream the outpu
 
 ## Remote builds
 
-Use templates to run build steps remotely. Build steps execute server-side in a transient sandbox; the result is a content-addressed filesystem snapshot cached server-side (~7 days), so re-running the same recipe is an instant cache hit.
+Use templates to run build steps remotely. Build steps execute server-side in a transient sandbox; the result is a content-addressed filesystem snapshot cached server-side, so re-running the same recipe is an instant cache hit.
 
 ### Build remotely
 
@@ -71,7 +71,7 @@ railway sandbox create --template ci             # boots from the cached snapsho
 railway sandbox exec -- npm start
 ```
 
-Template recipes are stored locally by this CLI — `Unknown template` means it was built elsewhere or never built; rebuild it with the command the error message prints.
+Template recipes are stored locally by this CLI — `Unknown template` means it was built elsewhere or never built; rebuild it with the command the error message prints. For state that must be reachable from other machines or later sessions, capture a [checkpoint](#checkpoints--save-and-restore-sandbox-state) instead.
 
 ### Inspect templates
 
@@ -98,6 +98,42 @@ railway sandbox fork <sandbox-id> --variable FOO=bar --private-network
 
 A fork copies the source's filesystem state but **does not inherit its variables or network mode** — re-pass `--variable`/`--env-file`/`--private-network` as needed.
 
+## Checkpoints — save and restore sandbox state
+
+Checkpoints are named disk snapshots captured from a running sandbox, stored server-side per environment. Use them to set a sandbox up once (clone a repo, install dependencies, seed data) and boot fresh sandboxes from that state later. Pick the right state mechanism:
+
+- **Template**: a reproducible recipe built from shell instructions — deterministic, but stored in this CLI's local store, so it only resolves on the machine that built it.
+- **Fork**: a live copy of a sandbox made right now.
+- **Checkpoint**: state you set up interactively, saved server-side by name — works from any machine or later agent session.
+
+### Capture
+
+```bash
+railway sandbox checkpoint create my-setup       # capture the active sandbox's disk
+railway sandbox checkpoint create my-setup --id <sandbox-id> --json
+```
+
+Capture is synchronous — the checkpoint is bootable as soon as the command returns, but flushing and uploading a large disk can take a while (the request honors `RAILWAY_HTTP_TIMEOUT`, so raise that rather than assuming a hang). Reusing a name **replaces the previous checkpoint without warning** — run `checkpoint list` first if overwriting matters. 64-character hex names are reserved for template hashes.
+
+### Boot from a checkpoint
+
+```bash
+railway sandbox create --checkpoint my-setup
+railway sandbox exec -- npm start
+```
+
+`--checkpoint` and `--template` are mutually exclusive. A checkpoint restores disk state only — variables and network mode are not part of the snapshot, so re-pass `--variable`/`--env-file`/`--private-network` on create as needed.
+
+### Manage checkpoints
+
+```bash
+railway sandbox checkpoint list --json
+railway sandbox checkpoint rename <name> <new-name>
+railway sandbox checkpoint delete <name>
+```
+
+Checkpoints are scoped to the environment: `list` shows only the linked environment's checkpoints, and `--checkpoint` resolves names within that scope. Deleting a checkpoint removes its underlying disk snapshot.
+
 ## List and teardown
 
 ```bash
@@ -113,8 +149,10 @@ Destroy sandboxes you created for a task once the task is done — idle timeout 
 
 - **Feature-availability error from the API**: Sandboxes aren't enabled for this workspace. Prompt the user to enable Sandboxes through Priority Boarding in the Railway dashboard; don't retry until they confirm.
 - **`No project selected` / `No environment selected`**: run `railway link` or pass `--project` with `--environment`.
-- **`Unknown template ...`**: the recipe isn't in this CLI's local store — rebuild with `railway sandbox template build --name <name> -c '<command>' --wait`.
+- **`Unknown template ...`**: the recipe isn't in this CLI's local store — rebuild with `railway sandbox template build --name <name> -c '<command>' --wait`, or use a checkpoint if the state was meant to travel between machines.
 - **`Template build failed`**: a step exited non-zero or exceeded its 10-minute limit; fix that step and rebuild.
+- **`No checkpoint named ...`**: checkpoints are environment-scoped — confirm the linked environment and run `railway sandbox checkpoint list`; the checkpoint may live in another environment or have been deleted/replaced.
+- **Checkpoint capture times out**: a large disk is still uploading — raise `RAILWAY_HTTP_TIMEOUT` (seconds) and retry rather than treating it as a failure.
 - **Exit code 124 from `exec`**: the client-side `--timeout` expired — rerun with a larger timeout or `--detach`.
 - **`that session may have expired; the server started a fresh one instead`**: the durable session lapsed; the command ran in a new session — check whether prior state mattered.
 - **SSH/forward drops**: the CLI reconnects automatically while the sandbox is RUNNING; if it reports the sandbox STOPPED, create or fork a new one.
@@ -122,4 +160,4 @@ Destroy sandboxes you created for a task once the task is done — idle timeout 
 ## Validated against
 
 - Docs: [sandboxes.md](https://docs.railway.com/sandboxes), [sandbox.md](https://docs.railway.com/cli/sandbox)
-- CLI source: [sandbox.rs](https://github.com/railwayapp/cli/blob/v5.8.0/src/commands/sandbox.rs), [sandbox_exec.rs](https://github.com/railwayapp/cli/blob/v5.8.0/src/controllers/sandbox_exec.rs)
+- CLI source: [sandbox.rs](https://github.com/railwayapp/cli/blob/v5.12.0/src/commands/sandbox.rs), [sandbox_exec.rs](https://github.com/railwayapp/cli/blob/v5.12.0/src/controllers/sandbox_exec.rs)


### PR DESCRIPTION
## What

Documents the sandbox checkpoint commands shipped in Railway CLI v5.12.0 ([railwayapp/cli#967](https://github.com/railwayapp/cli/pull/967)).

## Changes

**`references/sandbox.md`**
- New **Checkpoints** section covering the capture → boot → manage workflow (`checkpoint create/list/rename/delete`, `create --checkpoint`), with a chooser contrasting templates (local recipe, deterministic), fork (live copy now), and checkpoints (server-side by name — works from any machine or later agent session, which is the agent-shaped payoff)
- Operational caveats agents need: capture is synchronous and honors `RAILWAY_HTTP_TIMEOUT` (seconds) on large disks; reusing a name silently replaces the prior checkpoint; 64-character hex names are reserved for template hashes; a checkpoint restores disk only, so variables/network mode must be re-passed on create; checkpoints are environment-scoped
- Troubleshooting entries: `No checkpoint named ...` (environment scoping / deleted-or-replaced) and slow captures (raise `RAILWAY_HTTP_TIMEOUT`, don't treat as a hang)
- Dropped the "~7 days" template-cache claim (removed from CLI help in the same release) and bumped the validated CLI source pin v5.8.0 → v5.12.0

**Routing**
- Checkpoint trigger phrases ("checkpoint/snapshot the sandbox", "save/restore sandbox state") added to the sandbox intent line and reference table in `SKILL.md`, mirrored in `AGENTS.md`

**Versioning**
- Plugin version 1.2.6 → 1.3.0 across the Claude Code, Codex, and Cursor manifests, plus the `RAILWAY_CALLER` telemetry strings in `SKILL.md`

## Validation

- Behavior claims checked against the CLI source at the v5.12.0 tag (`src/commands/sandbox.rs`), including `--checkpoint`/`--template` mutual exclusion, synchronous capture, name-replacement semantics, and `RAILWAY_HTTP_TIMEOUT` units (seconds, `src/consts.rs` / `src/client.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)