### PR TITLE
Add root Grok plugin manifest for xAI marketplace (v1.2.7)

### DIFF
--- a/.grok-plugin/hooks.json
+++ b/.grok-plugin/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Auto-approve Railway API calls",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/plugins/railway/hooks/auto-approve-api.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "railway",
+  "version": "1.2.7",
+  "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway. Manage services, environments, deployments, databases, object storage, networking, and observability.",
+  "author": {
+    "name": "Railway",
+    "email": "contact@railway.com"
+  },
+  "homepage": "https://docs.railway.com/agents",
+  "repository": "https://github.com/railwayapp/railway-skills",
+  "license": "MIT",
+  "skills": ["./plugins/railway/skills/use-railway"],
+  "mcpServers": {
+    "railway": {
+      "command": "railway",
+      "args": ["mcp"]
+    }
+  },
+  "hooks": {
+    "description": "Auto-approve Railway API calls",
+    "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Bash",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/plugins/railway/hooks/auto-approve-api.sh"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -10,26 +10,6 @@
   "repository": "https://github.com/railwayapp/railway-skills",
   "license": "MIT",
   "skills": ["./plugins/railway/skills/use-railway"],
-  "mcpServers": {
-    "railway": {
-      "command": "railway",
-      "args": ["mcp"]
-    }
-  },
-  "hooks": {
-    "description": "Auto-approve Railway API calls",
-    "hooks": {
-      "PreToolUse": [
-        {
-          "matcher": "Bash",
-          "hooks": [
-            {
-              "type": "command",
-              "command": "${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/plugins/railway/hooks/auto-approve-api.sh"
-            }
-          ]
-        }
-      ]
-    }
-  }
+  "mcpServers": "./plugins/railway/.mcp.json",
+  "hooks": "./.grok-plugin/hooks.json"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The shared plugin payload lives in `plugins/railway`.
 
 - Claude Code: `plugins/railway/.claude-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.claude-plugin/marketplace.json`.
 - OpenAI Codex: `plugins/railway/.codex-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.agents/plugins/marketplace.json`.
-- Grok Build: consumes the Claude Code marketplace/plugin compatibility path through `.claude-plugin/marketplace.json` and `plugins/railway`. The xAI plugin marketplace (`xai-org/plugin-marketplace`) instead treats the repo root as the plugin, via the root manifest at `.grok-plugin/plugin.json`; that manifest points at the shared skill payload and inlines the MCP server and hook config with repo-root-relative paths.
+- Grok Build: consumes the Claude Code marketplace/plugin compatibility path through `.claude-plugin/marketplace.json` and `plugins/railway`. The xAI plugin marketplace (`xai-org/plugin-marketplace`) instead treats the repo root as the plugin, via the root manifest at `.grok-plugin/plugin.json`; that manifest references the shared skill payload and MCP config by path, plus a Grok-specific hooks file at `.grok-plugin/hooks.json`.
 - Cursor: `plugins/railway/.cursor-plugin/plugin.json`, `plugins/railway/.cursor-plugin/mcp.json`, and the repo marketplace at `.cursor-plugin/marketplace.json`.
 
 Claude Code and Grok Build also use `plugins/railway/hooks/hooks.json` for the existing Railway CLI/API auto-approval hook.
@@ -100,7 +100,8 @@ When editing this plugin:
 - Keep a single "Validated against" block at the end of each reference.
 - Keep plugin versions aligned across Claude Code, Codex, Cursor, and the root Grok manifest (`.grok-plugin/plugin.json`) when plugin behavior changes. Grok Build consumes the Claude Code manifest through compatibility; the xAI marketplace uses the root Grok manifest.
 - The xAI marketplace entry (`xai-org/plugin-marketplace`) pins this repo by commit SHA. After merging a release to `main`, bump the pinned `sha` in their `.grok-plugin/marketplace.json` and regenerate their plugin index, or users on the xAI catalog stay on the old commit.
-- Keep the inline `mcpServers` and `hooks` config in `.grok-plugin/plugin.json` in sync with `plugins/railway/.mcp.json` and `plugins/railway/hooks/hooks.json` (the inline hook command uses a repo-root-relative script path).
+- In `.grok-plugin/plugin.json`, reference components as paths (`skills` array, `mcpServers` and `hooks` as path strings). The Grok runtime ignores inline `mcpServers`/`hooks` objects in the manifest even though `grok plugin validate` accepts them — verify changes with `grok inspect` from a project that loads the repo as a plugin, not just `validate`.
+- Keep `.grok-plugin/hooks.json` in sync with `plugins/railway/hooks/hooks.json`; it differs only in the hook script path, which must be repo-root-relative (`.../plugins/railway/hooks/auto-approve-api.sh`) because the plugin root is the repo root for xAI marketplace installs.
 - Bump `version` in `plugins/railway/.claude-plugin/plugin.json` in any PR that changes skill content or published plugin behavior. Claude Code uses this version to detect updates, and users will not receive changes without a bump.
 
 ## References

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The shared plugin payload lives in `plugins/railway`.
 
 - Claude Code: `plugins/railway/.claude-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.claude-plugin/marketplace.json`.
 - OpenAI Codex: `plugins/railway/.codex-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.agents/plugins/marketplace.json`.
-- Grok Build: consumes the Claude Code marketplace/plugin compatibility path through `.claude-plugin/marketplace.json` and `plugins/railway`.
+- Grok Build: consumes the Claude Code marketplace/plugin compatibility path through `.claude-plugin/marketplace.json` and `plugins/railway`. The xAI plugin marketplace (`xai-org/plugin-marketplace`) instead treats the repo root as the plugin, via the root manifest at `.grok-plugin/plugin.json`; that manifest points at the shared skill payload and inlines the MCP server and hook config with repo-root-relative paths.
 - Cursor: `plugins/railway/.cursor-plugin/plugin.json`, `plugins/railway/.cursor-plugin/mcp.json`, and the repo marketplace at `.cursor-plugin/marketplace.json`.
 
 Claude Code and Grok Build also use `plugins/railway/hooks/hooks.json` for the existing Railway CLI/API auto-approval hook.
@@ -98,7 +98,9 @@ When editing this plugin:
 - Keep references action-oriented with reasoning. Explain why, not only what.
 - Keep CLI behavior claims aligned with Railway docs and CLI source.
 - Keep a single "Validated against" block at the end of each reference.
-- Keep plugin versions aligned across Claude Code, Codex, and Cursor manifests when plugin behavior changes. Grok Build consumes the Claude Code manifest through compatibility.
+- Keep plugin versions aligned across Claude Code, Codex, Cursor, and the root Grok manifest (`.grok-plugin/plugin.json`) when plugin behavior changes. Grok Build consumes the Claude Code manifest through compatibility; the xAI marketplace uses the root Grok manifest.
+- The xAI marketplace entry (`xai-org/plugin-marketplace`) pins this repo by commit SHA. After merging a release to `main`, bump the pinned `sha` in their `.grok-plugin/marketplace.json` and regenerate their plugin index, or users on the xAI catalog stay on the old commit.
+- Keep the inline `mcpServers` and `hooks` config in `.grok-plugin/plugin.json` in sync with `plugins/railway/.mcp.json` and `plugins/railway/hooks/hooks.json` (the inline hook command uses a repo-root-relative script path).
 - Bump `version` in `plugins/railway/.claude-plugin/plugin.json` in any PR that changes skill content or published plugin behavior. Claude Code uses this version to detect updates, and users will not receive changes without a bump.
 
 ## References

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using the Railway CLI and local MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"


### PR DESCRIPTION
## Why

The [xAI plugin marketplace](https://github.com/xai-org/plugin-marketplace) lists third-party plugins as remote `url` sources pinned to a commit SHA, and resolves the **repo root** as the plugin: components must live at the root or be declared in a root manifest (`.grok-plugin/plugin.json` is checked first). Our payload lives in `plugins/railway`, so a plain remote entry would install nothing.

## What

- Add a root `.grok-plugin/plugin.json` that references the shared payload **by path**:
  - `"skills": ["./plugins/railway/skills/use-railway"]`
  - `"mcpServers": "./plugins/railway/.mcp.json"`
  - `"hooks": "./.grok-plugin/hooks.json"`
- Add `.grok-plugin/hooks.json` — identical to `plugins/railway/hooks/hooks.json` except the hook script path is repo-root-relative (`$GROK_PLUGIN_ROOT/plugins/railway/hooks/auto-approve-api.sh`), since the plugin root is the repo root for xAI marketplace installs.
- Bump all manifests to **1.2.7** per the version convention
- Document the new manifest and the xAI SHA-pin maintenance step in AGENTS.md

The root manifest is Grok-only; Claude Code, Codex, and Cursor resolution paths are untouched.

## Verification (against the real Grok Build client, v0.2.20)

Path references are load-bearing: the Grok **runtime ignores inline `mcpServers`/`hooks` objects** in plugin.json even though `grok plugin validate` accepts them. Verified by loading the repo as a project plugin and running `grok inspect --json`:

```json
"provides": { "skills": 1, "agents": 0, "hooks": true, "mcpServers": 1 }
```

- On current `main` (no root manifest): Grok finds no plugin.json and auto-discovery at the repo root finds nothing — confirms the catalog entry would install an empty plugin without this change.
- xAI's `generate-plugin-index.py` scanner indexes the skill and hook (their scanner doesn't follow `mcpServers` path strings — display-only gap, same as MongoDB's entry; the runtime loads it fine).

## Follow-up

After this merges, the xAI catalog submission (prepared on the `m-abdelwahab/plugin-marketplace` fork) needs its pinned `sha` bumped to the squash-merge commit on `main` and the plugin index regenerated before opening the PR to `xai-org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)