### PR TITLE
use-railway: make repo root resolve as a Grok/xAI plugin (v1.3.1)

### DIFF
--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "railway",
+  "version": "1.3.1",
+  "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
+  "author": {
+    "name": "Railway",
+    "email": "contact@railway.com"
+  },
+  "homepage": "https://docs.railway.com/agents",
+  "repository": "https://github.com/railwayapp/railway-skills",
+  "license": "MIT",
+  "keywords": [
+    "railway",
+    "deployment",
+    "hosting",
+    "infrastructure",
+    "databases",
+    "mcp",
+    "agent-skills"
+  ]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,1 @@
+plugins/railway/.mcp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,10 @@ The shared plugin payload lives in `plugins/railway`.
 
 - Claude Code: `plugins/railway/.claude-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.claude-plugin/marketplace.json`.
 - OpenAI Codex: `plugins/railway/.codex-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.agents/plugins/marketplace.json`.
-- Grok Build: consumes the Claude Code marketplace/plugin compatibility path through `.claude-plugin/marketplace.json` and `plugins/railway`.
+- Grok Build / xAI marketplace: resolves the **repo root** as the plugin and auto-discovers components from standard root locations. The root therefore exposes `.grok-plugin/plugin.json` (metadata) plus three symlinks into the payload — `skills` → `plugins/railway/skills`, `hooks` → `plugins/railway/hooks`, `.mcp.json` → `plugins/railway/.mcp.json` — so no config is duplicated and `plugins/railway` stays the single source of truth.
 - Cursor: `plugins/railway/.cursor-plugin/plugin.json`, `plugins/railway/.cursor-plugin/mcp.json`, and the repo marketplace at `.cursor-plugin/marketplace.json`.
 
-Claude Code and Grok Build also use `plugins/railway/hooks/hooks.json` for the existing Railway CLI/API auto-approval hook.
+Claude Code and Grok Build also use `plugins/railway/hooks/hooks.json` for the existing Railway CLI/API auto-approval hook. The hook command resolves `${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh`, which works through the root `hooks` symlink under Grok.
 
 ## Skill model
 
@@ -98,7 +98,8 @@ When editing this plugin:
 - Keep references action-oriented with reasoning. Explain why, not only what.
 - Keep CLI behavior claims aligned with Railway docs and CLI source.
 - Keep a single "Validated against" block at the end of each reference.
-- Keep plugin versions aligned across Claude Code, Codex, and Cursor manifests when plugin behavior changes. Grok Build consumes the Claude Code manifest through compatibility.
+- Keep plugin versions aligned across the Claude Code, Codex, Cursor, and root Grok (`.grok-plugin/plugin.json`) manifests when plugin behavior changes.
+- The root `skills`, `hooks`, and `.mcp.json` symlinks must keep pointing into `plugins/railway`; never replace them with copies, or Grok and the payload will drift.
 - Bump `version` in `plugins/railway/.claude-plugin/plugin.json` in any PR that changes skill content or published plugin behavior. Claude Code uses this version to detect updates, and users will not receive changes without a bump.
 
 ## References

--- a/hooks
+++ b/hooks
@@ -1,0 +1,1 @@
+plugins/railway/hooks

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using the Railway CLI and local MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/skills
+++ b/skills
@@ -1,0 +1,1 @@
+plugins/railway/skills


### PR DESCRIPTION
## Why

The [xAI plugin marketplace](https://github.com/xai-org/plugin-marketplace) lists third-party plugins as remote `url` sources and **resolves the repo root as the plugin**, auto-discovering components from standard root locations (`skills/`, `hooks/hooks.json`, `.mcp.json`, `.grok-plugin/plugin.json`). Our payload lives at `plugins/railway`, so submitting the repo as-is would index and install **nothing**.

## What

Expose the payload at the repo root via three committed symlinks + a metadata-only Grok manifest, keeping `plugins/railway` as the single source of truth (no config duplication, mirrors the existing `CLAUDE.md → AGENTS.md` symlink):

| Root entry | Target |
|---|---|
| `skills` | `plugins/railway/skills` |
| `hooks` | `plugins/railway/hooks` |
| `.mcp.json` | `plugins/railway/.mcp.json` |
| `.grok-plugin/plugin.json` | new — metadata only; symlinks drive discovery |

The auto-approval hook already resolves `${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh`, which works through the root `hooks` symlink — no `hooks.json` duplication. All four manifests bumped to `1.3.1`.

## Verification

- **xAI scanner** — `generate-plugin-index.py`'s `resolve_inside()` resolves symlinks then checks containment, so it follows in-repo symlinks and rejects only escaping ones. Replicated its logic locally: all three components resolve inside root.
- **Grok runtime 0.2.20** — `grok plugin install <repo-root> --trust` + `grok plugin details railway` reports `railway v1.3.1` with `1 skill dir(s), hooks, MCP servers`. Test install removed afterward.

## Notes

- Windows checkouts need `git config core.symlinks true` (Unix/macOS clone fine).
- The root `.mcp.json` symlink means opening *this repo itself* in Claude Code/Cursor surfaces a project-scoped Railway MCP prompt (benign).

## Follow-up (separate repo)

After merge, the `xai-org/plugin-marketplace` catalog entry on the fork must pin the **merge-commit SHA**, regenerate the index, and open a PR upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)