### PR TITLE
Support Grok plugin subpath packaging

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,1 +1,0 @@
-plugins/railway/.mcp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,10 @@ The shared plugin payload lives in `plugins/railway`.
 
 - Claude Code: `plugins/railway/.claude-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.claude-plugin/marketplace.json`.
 - OpenAI Codex: `plugins/railway/.codex-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.agents/plugins/marketplace.json`.
-- Grok Build / xAI marketplace: resolves the **repo root** as the plugin and auto-discovers components from standard root locations. The root therefore exposes `.grok-plugin/plugin.json` (metadata) plus three symlinks into the payload — `skills` → `plugins/railway/skills`, `hooks` → `plugins/railway/hooks`, `.mcp.json` → `plugins/railway/.mcp.json` — so no config is duplicated and `plugins/railway` stays the single source of truth.
+- Grok Build / xAI marketplace: resolves `plugins/railway` as the plugin by using a remote source subpath (`source.path: "plugins/railway"`). The shared payload therefore exposes `plugins/railway/.grok-plugin/plugin.json`, `plugins/railway/skills`, `plugins/railway/hooks`, and `plugins/railway/.mcp.json` directly.
 - Cursor: `plugins/railway/.cursor-plugin/plugin.json`, `plugins/railway/.cursor-plugin/mcp.json`, and the repo marketplace at `.cursor-plugin/marketplace.json`.
 
-Claude Code and Grok Build also use `plugins/railway/hooks/hooks.json` for the existing Railway CLI/API auto-approval hook. The hook command resolves `${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh`, which works through the root `hooks` symlink under Grok.
+Claude Code and Grok Build also use `plugins/railway/hooks/hooks.json` for the existing Railway CLI/API auto-approval hook. The hook command resolves `${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh`.
 
 ## Skill model
 
@@ -98,8 +98,8 @@ When editing this plugin:
 - Keep references action-oriented with reasoning. Explain why, not only what.
 - Keep CLI behavior claims aligned with Railway docs and CLI source.
 - Keep a single "Validated against" block at the end of each reference.
-- Keep plugin versions aligned across the Claude Code, Codex, Cursor, and root Grok (`.grok-plugin/plugin.json`) manifests when plugin behavior changes.
-- The root `skills`, `hooks`, and `.mcp.json` symlinks must keep pointing into `plugins/railway`; never replace them with copies, or Grok and the payload will drift.
+- Keep plugin versions aligned across the Claude Code, Codex, Cursor, and Grok (`plugins/railway/.grok-plugin/plugin.json`) manifests when plugin behavior changes.
+- For Grok/xAI marketplace entries, use the remote source subpath `plugins/railway` instead of adding root-level symlinks or copies.
 - Bump `version` in `plugins/railway/.claude-plugin/plugin.json` in any PR that changes skill content or published plugin behavior. Claude Code uses this version to detect updates, and users will not receive changes without a bump.
 
 ## References

--- a/README.md
+++ b/README.md
@@ -80,18 +80,27 @@ GitHub repository from Cursor settings:
 
 ### Grok Build
 
-Add this GitHub repository as a Grok marketplace:
+Railway is packaged for Grok as the nested plugin at `plugins/railway`.
+Marketplace entries should point at that subpath with a pinned commit:
 
-```bash
-grok plugin marketplace add railwayapp/railway-skills
+```json
+{
+  "name": "railway",
+  "source": {
+    "source": "url",
+    "url": "https://github.com/railwayapp/railway-skills.git",
+    "sha": "<full commit sha>",
+    "path": "plugins/railway"
+  }
+}
 ```
 
-Then install the `railway` plugin from Grok's TUI:
+After the Railway entry is available in a Grok marketplace, install it from Grok's TUI:
 
 1. Run `grok`.
 2. Open the extensions modal with `/plugins`.
 3. Go to the **Marketplace** tab.
-4. Select `railway` from the `railway-skills` marketplace.
+4. Select `railway` from the marketplace.
 5. Press `i` to install.
 
 ## Skill surface

--- a/hooks
+++ b/hooks
@@ -1,1 +1,0 @@
-plugins/railway/hooks

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using the Railway CLI and local MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/skills
+++ b/skills
@@ -1,1 +1,0 @@
-plugins/railway/skills


### PR DESCRIPTION
## What

- Move the Grok plugin manifest into the shared Railway plugin payload at `plugins/railway/.grok-plugin/plugin.json`.
- Remove the root-level Grok compatibility symlinks for `.mcp.json`, `hooks`, and `skills`.
- Document the xAI/Grok marketplace source shape with `path: "plugins/railway"`.
- Bump the plugin manifests to `1.3.2` for the packaging behavior change.

## Why

The xAI marketplace tooling supports remote URL source subpaths via `source.path`, so Railway no longer needs to make the repo root resolve as the Grok plugin. Pointing the marketplace entry at `plugins/railway` keeps the shared payload as the single source of truth without root symlinks.

## Validation

- Parsed all plugin and marketplace JSON files locally.
- Confirmed all Railway plugin manifests report version `1.3.2`.
- Confirmed the xAI scanner sees `use-railway`, the `railway` MCP server, and the `PreToolUse` hook when rooted at `plugins/railway`.
- In a local clone of `xai-org/plugin-marketplace`, added a temporary Railway entry pinned to `7062066ca45064431e24951d0aeb3105544191c6` with `path: "plugins/railway"`, then ran:
  - `python3 scripts/generate-plugin-index.py`
  - `python3 scripts/generate-plugin-index.py --check`
  - `python3 scripts/validate-catalog.py`

## Follow-up

`xai-org/plugin-marketplace#35` should add `"path": "plugins/railway"` to the Railway source block and repin to this commit or a later one containing these changes.
