### PR TITLE
[codex] Refresh Railway skill for CLI v5.23.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ References:
 | Create or connect resources | `references/setup.md` | Projects, services, databases, buckets, templates, workspaces |
 | Ship code or manage releases | `references/deploy.md` | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | `references/configure.md` | Environments, variables, config patches, domains, networking |
+| Define or import project configuration as code | `references/iac.md` | Railway IaC, `.railway/railway.ts`, config init/pull/plan/apply, drift checks |
 | Check health or debug failures | `references/operate.md` | Status, logs, metrics, build/runtime triage, recovery |
 | Use a sandbox or build remotely | `references/sandbox.md` | Sandboxes: create/fork, remote exec, remote template builds, checkpoints, port forwarding (requires Priority Boarding) |
 | Analyze databases | `references/analyze-db.md` | Database introspection and performance analysis, then DB-specific refs |
@@ -94,7 +95,7 @@ API docs: https://docs.railway.com/api/llms-docs.md
 When editing this plugin:
 
 - Keep `SKILL.md` focused on routing, preflight, composition, and common operations.
-- Keep references organized by information type (setup, deploy, configure, operate, api).
+- Keep references organized by information type (setup, deploy, configure, iac, operate, api).
 - Keep references action-oriented with reasoning. Explain why, not only what.
 - Keep CLI behavior claims aligned with Railway docs and CLI source.
 - Keep a single "Validated against" block at the end of each reference.

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using the Railway CLI and local MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -96,7 +96,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.0" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.3" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -120,7 +120,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.0` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.3` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.
@@ -130,6 +130,7 @@ For Railway CLI calls made while this skill is active, prefix the command with `
 If the CLI is missing, guide the user to install it.
 
 ```bash
+curl -fsSL agents.railway.com | sh # Install CLI and configure detected agents
 bash <(curl -fsSL https://railway.com/install.sh) --agents -y # Install CLI and configure detected agents
 bash <(curl -fsSL https://railway.com/install.sh) # Shell script (macOS, Linux, Windows via WSL)
 npm i -g @railway/cli # npm (macOS, Linux, Windows). Requires Node.js version 16 or higher.
@@ -255,7 +256,9 @@ railway add --database <type> --json                     # add one database; ALW
 railway add --service <name> --json                      # add empty service; ALWAYS pass --json
 railway variable list --service <svc> --json             # list variables
 railway variable set KEY=value --service <svc>           # set a variable
+railway domain list --service <svc> --json               # domains and DNS status
 railway logs --service <svc> --lines 200 --json          # recent logs
+railway logs --service <svc> --network --lines 200 --json # network flow snapshot
 railway metrics --service <svc> --since 1h --json        # resource and HTTP metrics summary
 railway up --detach -m "<summary>"                       # deploy current directory (returns at QUEUED — verify before reporting)
 railway deployment list --json                           # poll newest deployment status after a detached up
@@ -274,6 +277,7 @@ For anything beyond quick operations, load the reference that matches the user's
 | Create or connect resources | [setup.md](references/setup.md) | Projects, services, databases, buckets, templates, workspaces |
 | Ship code or manage releases | [deploy.md](references/deploy.md) | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | [configure.md](references/configure.md) | Environments, variables, config patches, domains, networking |
+| Define or import project configuration as code ("IaC", "infrastructure as code", ".railway/railway.ts", "config plan/apply/pull") | [iac.md](references/iac.md) | Project-level Railway configuration files, import, plan, apply, drift checks, destructive apply safety |
 | Check health or debug failures | [operate.md](references/operate.md) | Status, logs, metrics, build/runtime triage, recovery |
 | Use a sandbox or build remotely ("sandbox", "scratch environment", "ephemeral box", "build remotely", "remote build", "run this remotely", "checkpoint", "snapshot/save/restore sandbox state") | [sandbox.md](references/sandbox.md) | Create/fork sandboxes, run commands remotely, remote template builds, checkpoints (save/restore sandbox state), port forwarding, teardown. Requires Sandboxes enabled in Priority Boarding — if unavailable, prompt the user to enable it. |
 | Request from API, docs, or community | [request.md](references/request.md) | Railway GraphQL API queries/mutations, metrics queries, Central Station, official docs |
@@ -289,7 +293,7 @@ If the request spans two areas (for example, "deploy and then check if it's heal
 5. Resolve context before mutation. Know which project, environment, and service you're acting on.
 6. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
 7. After mutations, verify the result with a read-back command or MCP read.
-8. **Never report a deploy as successful without observing a terminal SUCCESS.** `railway up --detach` returning (it prints "Build queued") and a streaming `railway up` cut off by a shell timeout only confirm the build *started*. Poll `railway deployment list --json` until the newest deployment's `status` is `SUCCESS` (report deployed), or `FAILED`/`CRASHED` (triage per [operate.md](references/operate.md) — do not claim success). A streaming `up` that exits on its own is authoritative: exit 0 = deployed, exit 1 = failed.
+8. **Never report a deploy as successful without observing a terminal SUCCESS.** `railway up --detach` returning (it prints "Build queued") and a streaming `railway up` cut off by a shell timeout only confirm the build *started*. Poll `railway deployment list --json` with the same `--project`, `--environment`, and `--service` scope used for the deploy until the newest deployment's `status` is `SUCCESS` (report deployed). If status is `FAILED` or `CRASHED`, triage per [operate.md](references/operate.md). If status is `NEEDS_APPROVAL`, `SLEEPING`, `SKIPPED`, `REMOVED`, `REMOVING`, or an unknown value, report the exact state and next action; do not claim success. A streaming `up` that exits on its own is authoritative: exit 0 = deployed, exit 1 = failed.
 
 ## User-only commands (NEVER execute directly)
 

--- a/plugins/railway/skills/use-railway/references/configure.md
+++ b/plugins/railway/skills/use-railway/references/configure.md
@@ -230,29 +230,41 @@ railway service list --json
 
 ## Domains
 
-### Railway domain
+Use the `railway domain` command for domain lifecycle work. Avoid raw `environment edit` JSON patches for normal domain management.
 
-One Railway-provided domain per service, generated automatically:
-
-```bash
-railway domain --service <service> --json
-```
-
-### Custom domain
+### Create domains
 
 ```bash
-railway domain example.com --service <service> --json
-```
-
-This returns the DNS records you need to configure at your DNS provider. Multiple custom domains per service are supported.
-
-### Target port
-
-If the service listens on a non-default port:
-
-```bash
+railway domain --service <service> --json                  # generate a Railway domain
+railway domain example.com --service <service> --json      # add a custom domain
 railway domain example.com --service <service> --port 8080 --json
 ```
+
+One Railway-provided domain is allowed per service. Multiple custom domains are supported. Custom domain creation returns the DNS records to add at the DNS provider. Add both the routing record and ownership verification record exactly as returned.
+
+Requests to a custom domain can return `404` until Railway verifies the ownership `TXT` record. DNS can take up to 72 hours to propagate.
+
+### Inspect and update domains
+
+```bash
+railway domain list --service <service> --json
+railway domain status example.com --service <service> --json
+railway domain update example.com --port 8080 --service <service> --json
+railway domain update old-name.up.railway.app --domain new-name --service <service> --json
+railway domain certificate retry example.com --service <service> --json
+```
+
+Use `status` when DNS or certificate issuance is not healthy. Retry certificate issuance only after fixing DNS.
+
+### Delete domains
+
+```bash
+railway domain delete example.com --service <service> --yes --json
+```
+
+Domain deletion is destructive. Confirm the domain and service before running it.
+
+## Networking commands
 
 ### Private networking
 
@@ -262,48 +274,87 @@ For service-to-service traffic within a project, use private domain references i
 BACKEND_URL=http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}
 ```
 
-### Read current domains
-
-Domain configuration lives in `config.services.<service-id>.networking` under `serviceDomains` (Railway-provided) and `customDomains`. Inspect with:
-
 ```bash
-railway environment config --json
+railway private-network status --service <service> --json
+railway private-network update api-internal --service <service> --json
 ```
 
-### Remove a domain
+When multiple private networks exist, pass `--network <name-or-id>`. Endpoint updates take the prefix only, without `.internal`.
 
-Remove domains via JSON config patch by setting the domain ID to `null`:
+### TCP proxies
 
-**Remove a custom domain:**
-
-```bash
-railway environment edit --json <<'JSON'
-{"services":{"<service-id>":{"networking":{"customDomains":{"<domain-id>":null}}}}}
-JSON
-```
-
-**Remove a Railway-provided domain:**
+Use TCP proxies to expose non-HTTP ports, such as database or game server ports, to the public internet. Only one TCP proxy is allowed per service instance.
 
 ```bash
-railway environment edit --json <<'JSON'
-{"services":{"<service-id>":{"networking":{"serviceDomains":{"<domain-id>":null}}}}}
-JSON
+railway tcp-proxy list --service <service> --json
+railway tcp-proxy create --service <service> --port 5432 --json
+railway tcp-proxy status <proxy-id-or-domain-or-port> --service <service> --json
+railway tcp-proxy delete <proxy-id-or-domain-or-port> --service <service> --yes --json
 ```
 
-Get the domain IDs from `railway environment config --json` under the service's `networking` object.
+TCP proxy creation updates service networking config. If the proxy does not become active, redeploy the service and check status.
+
+### Outbound networking
+
+Use outbound networking commands for Static Outbound IPs and outbound IPv6:
+
+```bash
+railway outbound-network status --service <service> --json
+railway outbound-network static-ip status --service <service> --json
+railway outbound-network static-ip enable --service <service> --json
+railway outbound-network static-ip disable --service <service> --json
+railway outbound-network ipv6 status --service <service> --json
+railway outbound-network ipv6 enable --service <service> --json
+railway outbound-network ipv6 disable --service <service> --json
+```
+
+Static Outbound IP changes are committed directly but require a redeploy before outbound traffic uses the new assignment. Outbound IPv6 changes are staged as environment config changes; commit staged changes with `railway environment edit` to trigger the redeploy.
+
+### CDN caching
+
+CDN caching is service-scoped and requires an applied public domain.
+
+```bash
+railway cdn status --service <service> --json
+railway cdn enable --service <service> --json
+railway cdn update --service <service> --html-caching force --default-ttl 4h --json
+railway cdn update --service <service> --no-swr --purge-on-deploy all --json
+railway cdn purge html --service <service> --json
+railway cdn purge all --service <service> --json
+railway cdn disable --service <service> --json
+```
+
+Use the response headers `x-cache` and `age` to verify cache behavior. Cache hits do not reach the service, so service logs and server-side metrics can undercount traffic after caching is enabled.
+
+### WAF Under Attack Mode
+
+Under Attack Mode is service-scoped, requires an applied public domain, and is intended for active bot floods or DDoS events.
+
+```bash
+railway waf under-attack status --service <service> --json
+railway waf under-attack enable --service <service> --duration 1h --json
+railway waf under-attack enable --service <service> --json
+railway waf under-attack disable --service <service> --json
+```
+
+While active, browser visitors must pass a check. Non-browser API clients and webhooks may receive `429` responses, so warn the user before enabling it on API-only domains.
 
 ## Troubleshoot configuration
 
 - **Invalid dot-path**: check field names and types in the config schema section above
 - **Wrong service key in JSON patch**: resolve service IDs from `railway service list --json`
 - **Variable change didn't take effect**: verify with `railway variable list`, changes trigger redeploy by default
-- **Domain returns errors**: verify the service has a healthy deployment and the target port is correct
-- **DNS propagation delay**: custom domains take time to propagate, this is normal
+- **Domain returns errors**: run `railway domain status`, verify the target port, then check HTTP logs
+- **DNS propagation delay**: custom domains can take up to 72 hours to propagate worldwide
 - **Cloudflare proxy issues**: align SSL/TLS mode per Railway's domain guidance
-- **Private networking failing**: verify the service is listening on the referenced port and that the private domain variable reference is correct
+- **Private networking failing**: run `railway private-network status`, verify the service is listening on the referenced port, and check network flow logs
+- **Outbound allowlist still sees old IPs**: redeploy after enabling/disabling Static Outbound IPs
+- **IPv6 still disabled**: commit the staged environment change and wait for redeploy
+- **CDN appears ineffective**: check `x-cache`, `age`, cache headers, `Set-Cookie`, `Authorization`, method, and response size
+- **WAF breaks API clients**: Under Attack Mode blocks non-browser traffic; disable it or scope protection to browser-facing services
 - **Multi-region patch ignored**: verify region names match the exact identifiers (`us-west2`, `us-east4-eqdc4a`, `europe-west4-drams3a`, `asia-southeast1-eqsg3a`)
 
 ## Validated against
 
-- Docs: [environment.md](https://docs.railway.com/cli/environment), [variable.md](https://docs.railway.com/cli/variable), [variables.md](https://docs.railway.com/variables), [domains.md](https://docs.railway.com/networking/domains), [public-networking.md](https://docs.railway.com/networking/public-networking), [private-networking.md](https://docs.railway.com/networking/private-networking)
-- CLI source: [environment/mod.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/environment/mod.rs), [environment/edit.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/environment/edit.rs), [variable.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/variable.rs), [domain.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/domain.rs), [controllers/config/patch.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/controllers/config/patch.rs)
+- Docs: [environment.md](https://docs.railway.com/cli/environment), [variable.md](https://docs.railway.com/cli/variable), [domain.md](https://docs.railway.com/cli/domain), [tcp-proxy.md](https://docs.railway.com/cli/tcp-proxy), [private-network.md](https://docs.railway.com/cli/private-network), [outbound-network.md](https://docs.railway.com/cli/outbound-network), [cdn.md](https://docs.railway.com/cli/cdn), [waf.md](https://docs.railway.com/cli/waf)
+- CLI source: [environment/mod.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/environment/mod.rs), [environment/edit.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/environment/edit.rs), [variable.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/variable.rs), [domain.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/domain.rs), [tcp_proxy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/tcp_proxy.rs), [private_network.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/private_network.rs), [outbound_networking.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/outbound_networking.rs), [cdn.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/cdn.rs), [waf.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/waf.rs)

--- a/plugins/railway/skills/use-railway/references/deploy.md
+++ b/plugins/railway/skills/use-railway/references/deploy.md
@@ -10,19 +10,24 @@ Ship code, manage releases, and configure builds.
 railway up --detach -m "<release summary>"
 ```
 
-`--detach` returns immediately instead of streaming build logs. Without it, the deploy blocks execution until the build finishes. Always include `-m` with a release summary for auditability.
+`--detach` (alias `--no-wait`) returns immediately instead of streaming build logs. Without it, the deploy blocks execution until the build finishes. Always include `-m` with a release summary for auditability.
 
 ### Verify before reporting — `--detach` only means QUEUED
 
 A detached `up` returns when the build is **queued**, not deployed. Never tell the user their app is deployed based on `--detach` output (or a streaming `up` that your shell timed out). Poll until the newest deployment reaches a terminal state:
 
 ```bash
-railway deployment list --json    # newest first; check .status
+railway deployment list --service <service> --environment <environment> --json    # newest first; check .status
+railway deployment list --project <project> --environment <environment> --service <service> --json
 ```
 
-- `QUEUED` / `BUILDING` / `DEPLOYING` → still in progress. Keep polling (every 10–15s); tell the user "build in progress" if you report interim status.
+Poll with the same project, environment, and service scope used for `railway up`. If the deploy used URL-derived IDs or `--project`, do not rely on the directory's linked context.
+
+- `QUEUED` / `INITIALIZING` / `WAITING` / `BUILDING` / `DEPLOYING` → still in progress. Keep polling (every 10-15s); tell the user "build in progress" if you report interim status.
+- `NEEDS_APPROVAL` → waiting for manual approval. Report that approval is required; do not keep polling as if the deployment is still building.
 - `SUCCESS` → now it's deployed; report it.
-- `FAILED` / `CRASHED` → do not report success. Pull logs (`railway logs --json --lines 100`) and triage per [operate.md](operate.md).
+- `FAILED` / `CRASHED` → do not report success. Pull scoped logs (`railway logs --service <service> --json --lines 100`) and triage per [operate.md](operate.md).
+- `SLEEPING` / `SKIPPED` / `REMOVED` / `REMOVING` / unknown → do not report success. Report the exact state and inspect status/logs to decide the next action.
 
 A non-detached `railway up` streams to completion and its exit code is authoritative: 0 = SUCCESS, 1 = FAILED/CRASHED. If it was killed or timed out before printing a terminal status, treat the outcome as unknown and poll as above.
 
@@ -51,6 +56,16 @@ railway up --project <project-id> --environment <environment> --detach -m "<summ
 ```
 
 `--project` requires `--environment`. Railway needs both to resolve context.
+
+### Path deploys
+
+Deploy a subdirectory without changing the shell's working directory:
+
+```bash
+railway up ./apps/api --path-as-root --service api --environment production --detach -m "<summary>"
+```
+
+Use `--path-as-root` when the path argument should be archived as the root of the deploy instead of preserving the parent directory prefix.
 
 ## Manage releases
 
@@ -85,7 +100,8 @@ Deleting a service is destructive. Confirm the target service and environment be
 ## Deployment history and logs
 
 ```bash
-railway deployment list --service <service> --limit 20 --json
+railway deployment list --service <service> --environment <environment> --limit 20 --json
+railway deployment list --project <project> --environment <environment> --service <service> --limit 20 --json
 railway logs --service <service> --lines 200 --json              # runtime logs
 railway logs --service <service> --build --lines 200 --json      # build logs
 railway logs --latest --lines 200 --json                         # latest deployment
@@ -206,4 +222,4 @@ railway environment edit --service-config <service> build.watchPatterns '["packa
 ## Validated against
 
 - Docs: [up.md](https://docs.railway.com/cli/up), [deploying.md](https://docs.railway.com/cli/deploying), [deployment.md](https://docs.railway.com/cli/deployment), [redeploy.md](https://docs.railway.com/cli/redeploy), [service.md](https://docs.railway.com/cli/service), [down.md](https://docs.railway.com/cli/down), [railpack.md](https://docs.railway.com/builds/railpack), [monorepo.md](https://docs.railway.com/deployments/monorepo)
-- CLI source: [up.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/up.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/deployment.rs), [down.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/down.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/redeploy.rs), [restart.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/restart.rs), [service.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/service.rs)
+- CLI source: [up.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/up.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/deployment.rs), [down.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/down.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/redeploy.rs), [restart.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/restart.rs), [service.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/service.rs)

--- a/plugins/railway/skills/use-railway/references/iac.md
+++ b/plugins/railway/skills/use-railway/references/iac.md
@@ -1,0 +1,108 @@
+# Infrastructure as Code
+
+Define, import, preview, and apply a Railway project from `.railway/railway.ts`.
+
+Use Railway IaC when the user wants project-level configuration in source control: services, databases, buckets, volumes, variables, replicas, domains, and canvas groups. Do not use it for a single-service deploy setting that is already owned by `railway.json` or `railway.toml`; migrate that service first so there is only one source of truth.
+
+## Files
+
+Railway IaC uses TypeScript:
+
+```text
+.railway/railway.ts
+.railway/README.md
+.agents/skills/railway-config/SKILL.md
+```
+
+`railway config init` and `railway config pull` create the support files when missing. The project-local `railway-config` skill helps future agents edit `.railway/railway.ts` safely.
+
+## Initialize or import
+
+```bash
+railway config init                         # create a starter .railway/railway.ts
+railway config init --force                 # overwrite existing generated files
+railway config pull                         # import the linked project
+railway config pull --force                 # overwrite existing .railway/railway.ts
+railway config pull --json                  # print current graph instead of writing files
+railway config pull --agent                 # ask an agent to clean the import afterward
+```
+
+If the directory is not linked, the CLI prompts for project/environment in an interactive terminal. In agent workflows, prefer linking first or passing explicit project/environment context when the CLI supports it.
+
+## Plan
+
+Always plan before applying:
+
+```bash
+railway config plan
+railway config plan --json
+railway config plan --verbose
+railway config plan --show-values
+railway config plan --detailed-exit-code
+```
+
+Plan output summarizes changes in Terraform style:
+
+```text
+Plan: 1 to add, 0 to change, 0 to destroy
+```
+
+Variable values are redacted by default. Use `--show-values` only when the user is intentionally reviewing non-secret config or accepts the secret exposure risk. Use `--detailed-exit-code` for CI drift checks: exit `0` means no changes, exit `2` means changes are pending, and other non-zero exits are errors.
+
+## Apply
+
+```bash
+railway config apply
+railway config apply --yes
+railway config apply --yes --confirm-destructive
+railway config apply --json --yes --confirm-destructive
+```
+
+`apply` always runs a fresh plan first. If the environment changed after the last plan, Railway rejects the apply and asks for a new plan. In non-interactive or agent sessions, destructive changes require `--confirm-destructive` in addition to `--yes` or `--json`; do not add it unless the user explicitly approved the destructive impact.
+
+## Authoring pattern
+
+Keep `.railway/railway.ts` readable and explicit:
+
+```ts
+import { defineRailway, project, service } from "railway/iac";
+
+export default defineRailway(() => {
+  const web = service("web", {
+    build: "pnpm build",
+    start: "pnpm start",
+  });
+
+  return project("my-project", {
+    resources: [web],
+  });
+});
+```
+
+Use imported helpers when needed: `service`, `postgres`, `redis`, `mysql`, `mongo`, `bucket`, `volume`, `group`, `github`, `image`, and `preserve`.
+
+## Migration from config as code
+
+When a service has `railway.json` or `railway.toml`:
+
+1. Run `railway config pull --force`.
+2. Translate only the intended service settings into `.railway/railway.ts`.
+3. Remove the old service-level config file or clear its custom config file path.
+4. Run `railway config plan`.
+5. Apply only when the plan matches the intended migration.
+
+If the plan shows unexpected service deletes, variable deletes, bucket deletes, or unrelated changes, stop and inspect the generated file before applying.
+
+## Troubleshoot IaC
+
+- **Service is already managed by `railway.json` or `railway.toml`**: migrate that service first; Railway blocks dual ownership.
+- **Plan shows secrets as hidden**: this is expected. Use `--show-values` only with user approval.
+- **Apply says the plan is stale**: run `railway config plan` again, inspect the new diff, then re-apply.
+- **Destructive apply blocked**: get explicit user approval and rerun with `--confirm-destructive`.
+- **Imported variables use `preserve()`**: Railway could not safely print encrypted secret values; preserve keeps the remote value.
+- **Generated code is too literal**: edit `.railway/railway.ts` into a cleaner shape, then verify with `railway config plan`.
+
+## Validated against
+
+- Docs: [infrastructure-as-code.md](https://docs.railway.com/infrastructure-as-code), [infrastructure-as-code/reference.md](https://docs.railway.com/infrastructure-as-code/reference)
+- CLI source: [config/mod.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/config/mod.rs), [config/runner.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/config/runner.rs)

--- a/plugins/railway/skills/use-railway/references/operate.md
+++ b/plugins/railway/skills/use-railway/references/operate.md
@@ -8,11 +8,15 @@ Start broad, then narrow:
 
 ```bash
 railway status --json                                    # linked context
+railway status --project <project> --environment <env> --json
 railway service list --json                              # services in current environment
 railway deployment list --limit 10 --json                # recent deployments
+railway deployment list --project <project> --environment <env> --service <service> --limit 10 --json
 ```
 
-Deployment statuses: `SUCCESS`, `BUILDING`, `DEPLOYING`, `FAILED`, `CRASHED`, `REMOVED`.
+Use explicit `--project`, `--environment`, and `--service` when the user provided a URL or when the current directory may be linked to a different project.
+
+Deployment statuses include `SUCCESS`, `QUEUED`, `INITIALIZING`, `WAITING`, `BUILDING`, `DEPLOYING`, `NEEDS_APPROVAL`, `FAILED`, `CRASHED`, `SLEEPING`, `SKIPPED`, `REMOVING`, and `REMOVED`.
 
 For projects with buckets, include bucket status:
 
@@ -52,7 +56,7 @@ railway logs --service <service> --lines 200 --filter "@level:warn AND timeout" 
 railway logs --service <service> --lines 200 --filter "connection refused" --json
 ```
 
-Filter syntax supports text search (`"error message"`), attribute filters (`@level:error`, `@level:warn`), and boolean operators (`AND`, `OR`, `-` for negation). Full syntax: https://docs.railway.com/guides/logs
+Filter syntax supports text search (`"error message"`), attribute filters (`@level:error`, `@level:warn`), and boolean operators (`AND`, `OR`, `-` for negation). Full syntax: https://docs.railway.com/cli/logs
 
 ### Scoped by environment
 
@@ -72,6 +76,33 @@ railway logs --service <service> --http --filter "@totalDuration:>=1000" --lines
 ```
 
 HTTP filter fields include `@method`, `@path`, `@host`, `@requestId`, `@srcIp`, `@edgeRegion`, `@httpStatus`, `@totalDuration`, `@responseTime`, `@txBytes`, and `@rxBytes`.
+
+### Network flow logs
+
+Use network flow logs for private networking, TCP proxy, outbound allowlist, DNS, or dropped-packet investigations:
+
+```bash
+railway logs --service <service> --network --lines 100 --json
+railway logs --service <service> --network --direction egress --protocol tcp --lines 100 --json
+railway logs --service <service> --network --peer postgres --port 5432 --lines 100 --json
+railway logs --service <service> --network --status dropped --lines 100 --json
+railway logs --service <service> --network --filter "@peer_kind:internet @port:443" --lines 100 --json
+```
+
+Network flow logs are service-level, not deployment-level. Do not pass a deployment ID or `--latest` with `--network`.
+
+Useful filters:
+
+| Flag | Use for |
+|---|---|
+| `--protocol tcp|udp|icmp|icmpv6|unknown` | Layer 4 protocol |
+| `--direction ingress|egress` | Traffic direction |
+| `--peer <service|internet|dns|edge-proxy>` | Named peer or well-known peer |
+| `--peer-kind service|internet|edge_proxy|local_dns|unknown` | Peer class |
+| `--status ok|dropped` / `--dropped true` | Dropped traffic |
+| `--port <port>` | Source or destination port |
+| `--src`, `--dst`, `--host` | IP filters |
+| `--drop-cause <cause>` | Drop reason |
 
 ## Metrics
 
@@ -174,12 +205,38 @@ Compare the config against expected values. Look for changes that may have intro
 Domain returns errors, or service-to-service calls fail:
 
 ```bash
-railway domain --service <service> --json
-railway logs --service <service> --lines 200 --json
+railway domain list --service <service> --json
+railway domain status <domain> --service <service> --json
+railway private-network status --service <service> --json
+railway tcp-proxy list --service <service> --json
+railway outbound-network status --service <service> --json
 railway logs --service <service> --http --status ">=400" --lines 100 --json
+railway logs --service <service> --network --status dropped --lines 100 --json
 ```
 
-Check: target port matches what the service listens on, domain status is healthy, private domain variable references are correct.
+Check: target port matches what the service listens on, domain status is healthy, private domain variable references are correct, TCP proxy status is active, and outbound networking changes have been followed by the required redeploy.
+
+### CDN and WAF incidents
+
+For cache behavior, inspect both CLI settings and response headers:
+
+```bash
+railway cdn status --service <service> --json
+railway logs --service <service> --http --status ">=400" --lines 100 --json
+curl -I https://<domain>/<path>
+curl https://<domain>/.railway/cdn-trace?json
+```
+
+`x-cache: HIT` means the request did not reach the service. `DYNAMIC` means the edge reached the service but did not cache the response. Check method, `Authorization`, `Set-Cookie`, `Cache-Control`, `Vary`, response size, and HTML caching mode.
+
+For active traffic floods or unexpected `429` responses:
+
+```bash
+railway waf under-attack status --service <service> --json
+railway logs --service <service> --http --status 429 --lines 100 --json
+```
+
+Under Attack Mode can block API clients and webhooks. If the service is API-only, disabling WAF may be the correct recovery after confirming with the user.
 
 ## Recovery
 
@@ -194,7 +251,7 @@ railway variable set MISSING_VAR=value --service <service>
 railway redeploy --service <service> --yes
 
 # Verify
-railway service status --service <service> --json
+railway deployment list --service <service> --limit 5 --json
 railway logs --service <service> --lines 200 --json
 ```
 
@@ -204,11 +261,13 @@ Always verify after fixing. Don't assume the redeploy succeeded.
 
 - **Unlinked context**: `railway link --project <id-or-name>`
 - **Missing service scope for logs**: pass `--service` and `--environment` explicitly
+- **Wrong project in status or deploy polling**: pass `--project`, `--environment`, and `--service`; URL IDs beat local linked context
 - **No deployments found**: the service exists but has never deployed, create an initial deploy first
 - **Metrics return empty**: check the time window, service scope, and whether the service has active deployments
 - **Config patch type error**: check the typed paths in [configure.md](configure.md), for example, `numReplicas` is an integer, not a string
+- **No network flow logs**: confirm the time window and service scope; network logs are not tied to deployment IDs
 
 ## Validated against
 
-- Docs: [status.md](https://docs.railway.com/cli/status), [service.md](https://docs.railway.com/cli/service), [logs.md](https://docs.railway.com/cli/logs), [metrics.md](https://docs.railway.com/cli/metrics), [ssh.md](https://docs.railway.com/cli/ssh), [observability/logs.md](https://docs.railway.com/observability/logs), [observability/metrics.md](https://docs.railway.com/observability/metrics)
-- CLI source: [status.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/status.rs), [service.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/service.rs), [logs.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/logs.rs), [metrics.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/metrics.rs), [ssh/mod.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/ssh/mod.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/deployment.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/redeploy.rs)
+- Docs: [status.md](https://docs.railway.com/cli/status), [service.md](https://docs.railway.com/cli/service), [logs.md](https://docs.railway.com/cli/logs), [metrics.md](https://docs.railway.com/cli/metrics), [ssh.md](https://docs.railway.com/cli/ssh), [cdn.md](https://docs.railway.com/cli/cdn), [waf.md](https://docs.railway.com/cli/waf), [observability/logs.md](https://docs.railway.com/observability/logs), [observability/metrics.md](https://docs.railway.com/observability/metrics)
+- CLI source: [status.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/status.rs), [service.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/service.rs), [logs.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/logs.rs), [metrics.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/metrics.rs), [ssh/mod.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/ssh/mod.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/deployment.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/redeploy.rs), [cdn.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/cdn.rs), [waf.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/waf.rs)

--- a/plugins/railway/skills/use-railway/references/request.md
+++ b/plugins/railway/skills/use-railway/references/request.md
@@ -19,14 +19,17 @@ Common doc paths:
 
 | Topic | Path |
 |---|---|
-| Projects | `guides/projects` |
-| Deployments | `guides/deployments` |
-| Volumes | `guides/volumes` |
-| Variables | `guides/variables` |
-| CLI reference | `reference/cli-api` |
-| Pricing | `reference/pricing` |
+| Agent setup | `agents`, `ai/agent-skills`, `ai/mcp-server` |
+| CLI reference | `cli`, `cli/<command>` |
+| Projects | `projects` |
+| Deployments | `deployments` |
+| Volumes | `volumes` |
+| Variables | `variables` |
+| Infrastructure as Code | `infrastructure-as-code`, `infrastructure-as-code/reference` |
 | Public networking | `networking/public-networking` |
 | Private networking | `networking/private-networking` |
+| Domains, CDN, WAF | `networking/domains`, `networking/cdn`, `networking/waf` |
+| Outbound networking | `networking/outbound-networking`, `networking/static-outbound-ips` |
 
 Fetch official docs first for product behavior questions. Use Central Station only when you need community evidence, prior incidents, or implementation anecdotes.
 
@@ -176,11 +179,13 @@ Use the CLI for template search:
 
 ```bash
 railway templates search redis --verified true --json
-railway templates search --category database --limit 10 --json
+railway templates search --category Storage --limit 10 --json
 railway templates search --after <cursor> --json
+railway templates list --json
+railway templates create --project <project> --environment production --json
 ```
 
-The CLI search command doesn't require authentication and supports pagination with `pageInfo.endCursor`.
+The CLI search command doesn't require authentication and supports pagination with `pageInfo.endCursor`. Prefer CLI template commands for search, listing owned templates, creating drafts, publishing, unpublishing, and deleting. Use GraphQL only for template workflows the CLI cannot express.
 
 Use GraphQL only when the CLI output isn't enough for the workflow:
 
@@ -207,6 +212,15 @@ Deploy a found template via CLI:
 
 ```bash
 railway deploy --template <template-code>
+```
+
+Manage owned templates via CLI:
+
+```bash
+railway templates publish <template-id> --category Other --description "Deploy and Host My App with Railway" --readme-file README.md --json
+railway templates update <template-id> --category Other --description "Updated description" --readme-file README.md --json
+railway templates unpublish <template-id-or-code> --yes --json
+railway templates delete <template-id-or-code> --yes --json
 ```
 
 ### GraphQL template deployment
@@ -244,5 +258,5 @@ scripts/railway-api.sh \
 
 ## Validated against
 
-- Docs: [api docs](https://docs.railway.com/api/llms-docs.md), [community.md](https://docs.railway.com/community), [cli/docs.md](https://docs.railway.com/cli/docs), [templates.md](https://docs.railway.com/cli/templates), [metrics.md](https://docs.railway.com/cli/metrics)
-- CLI source: [docs.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/docs.rs), [templates.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/templates.rs), [metrics.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/metrics.rs)
+- Docs: [api docs](https://docs.railway.com/api/llms-docs.md), [agents.md](https://docs.railway.com/agents), [community.md](https://docs.railway.com/community), [cli/docs.md](https://docs.railway.com/cli/docs), [templates.md](https://docs.railway.com/cli/templates), [metrics.md](https://docs.railway.com/cli/metrics)
+- CLI source: [docs.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/docs.rs), [templates.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/templates.rs), [metrics.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/metrics.rs)

--- a/plugins/railway/skills/use-railway/references/sandbox.md
+++ b/plugins/railway/skills/use-railway/references/sandbox.md
@@ -73,6 +73,10 @@ railway sandbox exec -- npm start
 
 Template recipes are stored locally by this CLI — `Unknown template` means it was built elsewhere or never built; rebuild it with the command the error message prints. For state that must be reachable from other machines or later sessions, capture a [checkpoint](#checkpoints--save-and-restore-sandbox-state) instead.
 
+## Agents in sandboxes
+
+Use sandboxes for agent runs that need isolated compute, private networking to Railway resources, or remote build/test execution. Copy or generate code in the sandbox, run the agent or test command with `sandbox exec`, and capture a checkpoint if the state should be reused across machines. Prefer `--private-network` when the agent needs internal service or database access.
+
 ### Inspect templates
 
 ```bash
@@ -159,5 +163,5 @@ Destroy sandboxes you created for a task once the task is done — idle timeout 
 
 ## Validated against
 
-- Docs: [sandboxes.md](https://docs.railway.com/sandboxes), [sandbox.md](https://docs.railway.com/cli/sandbox)
-- CLI source: [sandbox.rs](https://github.com/railwayapp/cli/blob/v5.12.0/src/commands/sandbox.rs), [sandbox_exec.rs](https://github.com/railwayapp/cli/blob/v5.12.0/src/controllers/sandbox_exec.rs)
+- Docs: [sandboxes.md](https://docs.railway.com/sandboxes), [sandbox.md](https://docs.railway.com/cli/sandbox), [agents-in-sandboxes.md](https://docs.railway.com/guides/agents-in-sandboxes)
+- CLI source: [sandbox.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/sandbox.rs), [sandbox_exec.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/controllers/sandbox_exec.rs)

--- a/plugins/railway/skills/use-railway/references/setup.md
+++ b/plugins/railway/skills/use-railway/references/setup.md
@@ -128,6 +128,20 @@ Service names in variable references are case-sensitive and must match exactly. 
 
 When creating new service instances via JSON config patches, include `isCreated: true` in the service block to mark it as a new service.
 
+### Connect to a database shell
+
+Use `railway connect` when the user wants an interactive database shell (`psql`, `redis-cli`, `mysql`, or `mongosh`):
+
+```bash
+railway connect <database-service>
+railway connect <database-service> --environment production
+railway connect <database-service> --project <project-id> --environment production
+railway connect <database-service> --ssh
+railway connect <database-service> --no-ssh
+```
+
+The local database client must be installed. By default, `connect` uses a public TCP proxy when one exists and falls back to an SSH tunnel when no public proxy URL is available. Use `--ssh` to force the tunnel path, or `--no-ssh` to require a public TCP proxy.
+
 ### Delete a service
 
 Deleting a service removes it from the target environment. Confirm with the user before running it.
@@ -141,11 +155,12 @@ If 2FA is enabled and the command runs non-interactively, pass `--2fa-code <code
 
 ### Deploy from a template
 
-Templates provision pre-configured services with sensible defaults, faster than creating an empty service and configuring it manually:
+Templates provision pre-configured services with sensible defaults, faster than creating an empty service and configuring it manually. Use `templates search` for marketplace discovery and `deploy --template` for deployment:
 
 ```bash
 railway templates search postgres --verified true --json
-railway templates search --category database --limit 10 --json
+railway templates search --category Storage --limit 10 --json
+railway templates search postgres --limit 50 --after <cursor> --json
 railway deploy --template <template-code>
 ```
 
@@ -157,6 +172,20 @@ Template deployments typically create:
 - Environment variables (connection strings, secrets)
 - A volume for persistent data (databases)
 - A TCP proxy for external access (where applicable)
+
+Manage owned templates with:
+
+```bash
+railway templates list --json
+railway templates list --workspace <workspace> --json
+railway templates create --project <project> --environment production --json
+railway templates publish <template-id> --category Other --description "Deploy and Host My App with Railway" --readme-file README.md --json
+railway templates update <template-id> --category Other --description "Updated description" --readme-file README.md --json
+railway templates unpublish <template-id-or-code> --yes --json
+railway templates delete <template-id-or-code> --yes --json
+```
+
+Non-interactive `unpublish` and `delete` require `--yes`; pass `--2fa-code` when required by the current auth session.
 
 ### Bootstrap source for an empty service
 
@@ -325,10 +354,11 @@ When creating projects, Railway uses the default workspace unless `--workspace` 
 - **Not authenticated**: `railway login`
 - **Project not found**: verify with `railway project list --json`, check workspace context
 - **Service not found**: `railway service list --json` to list services in the current environment
+- **Database shell cannot connect**: install the local database client, use `railway connect <service> --ssh`, or create/check a TCP proxy
 - **Wrong workspace**: inspect `railway whoami --json`, re-run with explicit `--workspace`
 - **Permission denied**: check workspace role, mutations require member or admin access
 
 ## Validated against
 
-- Docs: [cli.md](https://docs.railway.com/cli), [init.md](https://docs.railway.com/cli/init), [add.md](https://docs.railway.com/cli/add), [link.md](https://docs.railway.com/cli/link), [project.md](https://docs.railway.com/cli/project), [service.md](https://docs.railway.com/cli/service), [templates.md](https://docs.railway.com/cli/templates), [list.md](https://docs.railway.com/cli/list), [whoami.md](https://docs.railway.com/cli/whoami)
-- CLI source: [init.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/init.rs), [add.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/add.rs), [project.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/project.rs), [service.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/service.rs), [templates.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/templates.rs), [list.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/list.rs), [bucket.rs](https://github.com/railwayapp/cli/blob/v4.58.0/src/commands/bucket.rs)
+- Docs: [cli.md](https://docs.railway.com/cli), [init.md](https://docs.railway.com/cli/init), [add.md](https://docs.railway.com/cli/add), [link.md](https://docs.railway.com/cli/link), [project.md](https://docs.railway.com/cli/project), [service.md](https://docs.railway.com/cli/service), [connect.md](https://docs.railway.com/cli/connect), [templates.md](https://docs.railway.com/cli/templates), [list.md](https://docs.railway.com/cli/list), [whoami.md](https://docs.railway.com/cli/whoami)
+- CLI source: [init.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/init.rs), [add.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/add.rs), [project.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/project.rs), [service.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/service.rs), [connect.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/connect.rs), [templates.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/templates.rs), [list.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/list.rs), [bucket.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/bucket.rs)


### PR DESCRIPTION
## Summary

Refreshes the Railway `use-railway` skill against the latest released Railway CLI and docs surface inspected through CLI `v5.23.3`.

## What changed

- Adds a dedicated IaC reference for `.railway/railway.ts`, `railway config init/pull/plan/apply`, drift checks, and destructive apply safety.
- Updates skill routing, telemetry versioning, installer copy, deploy polling, and quick operations.
- Refreshes domain, DNS, networking, CDN, WAF, network-flow-log, template, database-connect, sandbox, and docs/API guidance.
- Bumps Claude, Codex, Cursor, and Grok plugin manifests to `1.3.3`.

## Why

The Railway CLI and docs have added released command surfaces since the skill references were last updated. This keeps agent behavior aligned with current CLI commands and avoids relying on older config-patch flows where first-class commands now exist.

## Validation

- `git diff --check origin/main...HEAD`
- stale marker search for old versions/docs paths: `1.3.2`, `1.3.0`, `v4.58.0`, `v5.12.0`, old docs paths
- command-shape checks against the cloned Railway CLI source
- docs path checks against the cloned Railway docs repo

No live Railway account/project operations were run.