### PR TITLE
Use hosted MCP for Railway plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "railway-skills",
-  "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code.",
+  "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code.",
   "owner": {
     "name": "Railway",
     "email": "contact@railway.com"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "railway",
-      "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
+      "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
       "author": {
         "name": "Railway"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "email": "gtm@railway.com"
   },
   "metadata": {
-    "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor."
+    "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor."
   },
   "plugins": [
     {
       "name": "railway",
       "source": "plugins/railway",
-      "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability."
+      "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability."
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The shared plugin payload lives in `plugins/railway`.
 
 - Claude Code: `plugins/railway/.claude-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.claude-plugin/marketplace.json`.
 - OpenAI Codex: `plugins/railway/.codex-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.agents/plugins/marketplace.json`.
-- Grok Build / xAI marketplace: resolves `plugins/railway` as the plugin by using a remote source subpath (`source.path: "plugins/railway"`). The shared payload therefore exposes `plugins/railway/.grok-plugin/plugin.json`, `plugins/railway/skills`, `plugins/railway/hooks`, and `plugins/railway/.mcp.json` directly.
+- Grok Build / xAI marketplace: resolves `plugins/railway` as the plugin by using a remote source subpath (`source.path: "plugins/railway"`). The shared payload therefore exposes `plugins/railway/.grok-plugin/plugin.json`, `plugins/railway/.grok-plugin/mcp.json`, `plugins/railway/skills`, and `plugins/railway/hooks` directly.
 - Cursor: `plugins/railway/.cursor-plugin/plugin.json`, `plugins/railway/.cursor-plugin/mcp.json`, and the repo marketplace at `.cursor-plugin/marketplace.json`.
 
 Claude Code and Grok Build also use `plugins/railway/hooks/hooks.json` for the existing Railway CLI/API auto-approval hook. The hook command resolves `${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh`.
@@ -46,8 +46,8 @@ References:
 
 Choose the Railway operation path that matches the job.
 
-- Remote MCP (`https://mcp.railway.com`): account/project/service discovery, deployment status, bounded logs, simple redeploys, simple project creation, and complex workflows through `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
-- Local CLI MCP (`railway mcp`): CLI-backed platform operations such as variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
+- Remote MCP (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment status, bounded logs, simple redeploys, simple project creation, and complex workflows through `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
+- Local CLI MCP (`railway mcp`): optional user-installed MCP path for CLI-backed platform operations such as variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
 - Railway CLI (`railway`): local-machine workflows such as current-directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, and exact command output.
 - GraphQL: operations that neither MCP nor CLI exposes.
 
@@ -61,11 +61,12 @@ Use Railway CLI for context-aware local operations.
 
 ### MCP
 
-Railway CLI exposes a local MCP server with `railway mcp`.
+Published plugin MCP configs use Railway's hosted MCP server for single-click setup.
 
-- Keep `plugins/railway/.mcp.json` and `plugins/railway/.cursor-plugin/mcp.json` in sync.
-- The local MCP config must run `railway mcp`.
-- Do not store credentials in plugin MCP config. Railway CLI authentication comes from the user's local Railway login.
+- Keep `plugins/railway/.mcp.json`, `plugins/railway/.cursor-plugin/mcp.json`, and `plugins/railway/.grok-plugin/mcp.json` in sync.
+- Plugin MCP configs must point at `https://mcp.railway.com` with HTTP transport.
+- Do not store credentials in plugin MCP config. Remote MCP authentication uses Railway OAuth.
+- Railway CLI still exposes `railway mcp` for users who explicitly install a local CLI-backed MCP server, but published plugin configs should not launch it.
 
 ### GraphQL API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,10 +46,11 @@ References:
 
 Choose the Railway operation path that matches the job.
 
-- Remote MCP (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment status, bounded logs, simple redeploys, simple project creation, and complex workflows through `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
-- Local CLI MCP (`railway mcp`): optional user-installed MCP path for CLI-backed platform operations such as variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
 - Railway CLI (`railway`): local-machine workflows such as current-directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, and exact command output.
+- Remote MCP (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment status, bounded logs, simple redeploys, simple project creation, and complex workflows through `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
 - GraphQL: operations that neither MCP nor CLI exposes.
+
+Optional: if the current agent already has a user-installed local CLI MCP (`railway mcp`) configured, it can be used for CLI-backed platform operations not yet exposed by remote MCP. Published plugin configs do not install or launch local CLI MCP.
 
 ### Railway CLI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The shared plugin payload lives in `plugins/railway`.
 
 - Claude Code: `plugins/railway/.claude-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.claude-plugin/marketplace.json`.
 - OpenAI Codex: `plugins/railway/.codex-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.agents/plugins/marketplace.json`.
-- Grok Build / xAI marketplace: resolves `plugins/railway` as the plugin by using a remote source subpath (`source.path: "plugins/railway"`). The shared payload therefore exposes `plugins/railway/.grok-plugin/plugin.json`, `plugins/railway/.grok-plugin/mcp.json`, `plugins/railway/skills`, and `plugins/railway/hooks` directly.
+- Grok Build / xAI marketplace: resolves `plugins/railway` as the plugin by using a remote source subpath (`source.path: "plugins/railway"`). The shared payload therefore exposes `plugins/railway/.grok-plugin/plugin.json`, `plugins/railway/skills`, `plugins/railway/hooks`, and `plugins/railway/.mcp.json` directly.
 - Cursor: `plugins/railway/.cursor-plugin/plugin.json`, `plugins/railway/.cursor-plugin/mcp.json`, and the repo marketplace at `.cursor-plugin/marketplace.json`.
 
 Claude Code and Grok Build also use `plugins/railway/hooks/hooks.json` for the existing Railway CLI/API auto-approval hook. The hook command resolves `${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh`.
@@ -66,7 +66,6 @@ Railway CLI exposes a local MCP server with `railway mcp`.
 - Keep `plugins/railway/.mcp.json` and `plugins/railway/.cursor-plugin/mcp.json` in sync.
 - The local MCP config must run `railway mcp`.
 - Do not store credentials in plugin MCP config. Railway CLI authentication comes from the user's local Railway login.
-- Grok marketplace installs use `plugins/railway/.grok-plugin/mcp.json`, which points at the hosted `https://mcp.railway.com` MCP server for single-click setup without a local CLI dependency.
 
 ### GraphQL API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The shared plugin payload lives in `plugins/railway`.
 
 - Claude Code: `plugins/railway/.claude-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.claude-plugin/marketplace.json`.
 - OpenAI Codex: `plugins/railway/.codex-plugin/plugin.json`, `plugins/railway/.mcp.json`, and the repo marketplace at `.agents/plugins/marketplace.json`.
-- Grok Build / xAI marketplace: resolves `plugins/railway` as the plugin by using a remote source subpath (`source.path: "plugins/railway"`). The shared payload therefore exposes `plugins/railway/.grok-plugin/plugin.json`, `plugins/railway/skills`, `plugins/railway/hooks`, and `plugins/railway/.mcp.json` directly.
+- Grok Build / xAI marketplace: resolves `plugins/railway` as the plugin by using a remote source subpath (`source.path: "plugins/railway"`). The shared payload therefore exposes `plugins/railway/.grok-plugin/plugin.json`, `plugins/railway/.grok-plugin/mcp.json`, `plugins/railway/skills`, and `plugins/railway/hooks` directly.
 - Cursor: `plugins/railway/.cursor-plugin/plugin.json`, `plugins/railway/.cursor-plugin/mcp.json`, and the repo marketplace at `.cursor-plugin/marketplace.json`.
 
 Claude Code and Grok Build also use `plugins/railway/hooks/hooks.json` for the existing Railway CLI/API auto-approval hook. The hook command resolves `${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh`.
@@ -66,6 +66,7 @@ Railway CLI exposes a local MCP server with `railway mcp`.
 - Keep `plugins/railway/.mcp.json` and `plugins/railway/.cursor-plugin/mcp.json` in sync.
 - The local MCP config must run `railway mcp`.
 - Do not store credentials in plugin MCP config. Railway CLI authentication comes from the user's local Railway login.
+- Grok marketplace installs use `plugins/railway/.grok-plugin/mcp.json`, which points at the hosted `https://mcp.railway.com` MCP server for single-click setup without a local CLI dependency.
 
 ### GraphQL API
 

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "railway",
-  "version": "1.3.3",
-  "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
+  "version": "1.3.4",
+  "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.4",
+  "version": "1.3.3",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.4",
+  "version": "1.3.3",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using the Railway CLI and local MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using the Railway CLI and local MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "railway",
-  "version": "1.3.3",
-  "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using the Railway CLI and local MCP server.",
+  "version": "1.3.4",
+  "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using Railway skills and the hosted MCP server.",
   "author": {
     "name": "Railway",
     "email": "gtm@railway.com",
@@ -24,7 +24,7 @@
   "interface": {
     "displayName": "Railway",
     "shortDescription": "Deploy, configure, monitor, and troubleshoot Railway apps.",
-    "longDescription": "Use Railway from Codex through the local Railway CLI MCP server and curated Railway skills. Deploy apps, manage services and environments, configure variables and domains, provision databases and object storage, inspect logs and metrics, and troubleshoot failed builds or deployments.",
+    "longDescription": "Use Railway from Codex through the hosted Railway MCP server and curated Railway skills. Deploy apps, manage services and environments, configure variables and domains, provision databases and object storage, inspect logs and metrics, and troubleshoot failed builds or deployments.",
     "developerName": "Railway",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/railway/.cursor-plugin/mcp.json
+++ b/plugins/railway/.cursor-plugin/mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "railway": {
-      "command": "railway",
-      "args": [
-        "mcp"
-      ]
+      "type": "http",
+      "url": "https://mcp.railway.com"
     }
   }
 }

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "railway",
   "displayName": "Railway",
-  "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.3",
+  "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
+  "version": "1.3.4",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.4",
+  "version": "1.3.3",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/mcp.json
+++ b/plugins/railway/.grok-plugin/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "railway": {
+      "type": "http",
+      "url": "https://mcp.railway.com"
+    }
+  }
+}

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "railway",
   "version": "1.3.4",
-  "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
+  "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Railway agent skills and MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",
@@ -9,6 +9,7 @@
   "homepage": "https://docs.railway.com/agents",
   "repository": "https://github.com/railwayapp/railway-skills",
   "license": "MIT",
+  "mcpServers": "./.grok-plugin/mcp.json",
   "keywords": [
     "railway",
     "deployment",

--- a/plugins/railway/.mcp.json
+++ b/plugins/railway/.mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "railway": {
-      "command": "railway",
-      "args": [
-        "mcp"
-      ]
+      "type": "http",
+      "url": "https://mcp.railway.com"
     }
   }
 }

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -35,11 +35,11 @@ Most CLI commands operate on the linked project/environment/service context. Use
 
 Railway has three agent-facing operation paths. Choose the path that matches the job:
 
-- **Remote MCP** (`https://mcp.railway.com`): account/project/service discovery, deployment state, bounded logs, simple redeploys, simple project creation, or complex Railway workflows that can be handed to `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
-- **Local CLI MCP** (`railway mcp`): CLI-backed platform operations such as variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
+- **Remote MCP** (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment state, bounded logs, simple redeploys, simple project creation, or complex Railway workflows that can be handed to `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
+- **Local CLI MCP** (`railway mcp`): optional user-installed MCP path for CLI-backed platform operations such as variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
 - **Railway CLI** (`railway`): workflows that depend on local machine state such as current working directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, or exact command output.
 
-If multiple paths are available, choose the one that preserves the needed context. Remote MCP fits OAuth-scoped platform operations that do not need local files or CLI state. Local CLI MCP or the CLI fit workflows that need the current repo, local credentials, SSH, database scripts, or commands not exposed by remote MCP.
+If multiple paths are available, choose the one that preserves the needed context. Remote MCP fits OAuth-scoped platform operations that do not need local files or CLI state. The CLI fits workflows that need the current repo, local credentials, SSH, database scripts, or commands not exposed by remote MCP. Use Local CLI MCP only when the current agent has it explicitly configured.
 
 Use `scripts/railway-api.sh` only when neither MCP nor CLI exposes the operation, or when a reference gives a specific GraphQL fallback.
 
@@ -96,7 +96,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.3" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.4" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -120,7 +120,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.3` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.4` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.
@@ -221,8 +221,8 @@ railway setup agent --remote
 Install or update MCP and skills directly when the user names a target tool:
 
 ```bash
-railway mcp install
-railway mcp install --agent codex
+railway mcp install --remote
+railway mcp install --agent codex --remote
 railway mcp install --agent cursor --remote
 railway skills
 railway skills update --agent codex

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -96,7 +96,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.3" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.4" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -120,7 +120,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.3` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.4` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -96,7 +96,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.4" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.3" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -120,7 +120,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.4` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.3` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -35,13 +35,15 @@ Most CLI commands operate on the linked project/environment/service context. Use
 
 Railway has three agent-facing operation paths. Choose the path that matches the job:
 
-- **Remote MCP** (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment state, bounded logs, simple redeploys, simple project creation, or complex Railway workflows that can be handed to `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
-- **Local CLI MCP** (`railway mcp`): optional user-installed MCP path for CLI-backed platform operations such as variables, domains, service config, templates, metrics, HTTP summaries, buckets, volumes, docs, or deploy-from-directory.
 - **Railway CLI** (`railway`): workflows that depend on local machine state such as current working directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, or exact command output.
+- **Remote MCP** (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment state, bounded logs, simple redeploys, simple project creation, or complex Railway workflows that can be handed to `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
+- **GraphQL**: operations that neither MCP nor CLI exposes, or when a reference gives a specific GraphQL fallback.
 
-If multiple paths are available, choose the one that preserves the needed context. Remote MCP fits OAuth-scoped platform operations that do not need local files or CLI state. The CLI fits workflows that need the current repo, local credentials, SSH, database scripts, or commands not exposed by remote MCP. Use Local CLI MCP only when the current agent has it explicitly configured.
+If multiple paths are available, choose the one that preserves the needed context. The CLI fits workflows that need the current repo, local credentials, SSH, database scripts, or exact command output. Remote MCP fits OAuth-scoped platform operations that do not need local files or CLI state.
 
-Use `scripts/railway-api.sh` only when neither MCP nor CLI exposes the operation, or when a reference gives a specific GraphQL fallback.
+Optional: if the current agent already has a user-installed local CLI MCP (`railway mcp`) configured, it can be used for CLI-backed platform operations not yet exposed by remote MCP. Published plugin configs do not install or launch local CLI MCP.
+
+Use `scripts/railway-api.sh` for GraphQL only when neither MCP nor CLI exposes the operation, or when a reference gives a specific GraphQL fallback.
 
 ## Parsing Railway URLs
 
@@ -286,14 +288,15 @@ If the request spans two areas (for example, "deploy and then check if it's heal
 
 ## Execution rules
 
-1. Use Railway MCP for platform operations that match an available MCP tool.
-2. Use the local CLI for workflows that need the current repo, local shell, SSH, database scripts, or unsupported MCP coverage.
-3. Fall back to `scripts/railway-api.sh` for operations neither MCP nor CLI exposes.
-4. Use `--json` output where available for reliable parsing.
-5. Resolve context before mutation. Know which project, environment, and service you're acting on.
-6. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
-7. After mutations, verify the result with a read-back command or MCP read.
-8. **Never report a deploy as successful without observing a terminal SUCCESS.** `railway up --detach` returning (it prints "Build queued") and a streaming `railway up` cut off by a shell timeout only confirm the build *started*. Poll `railway deployment list --json` with the same `--project`, `--environment`, and `--service` scope used for the deploy until the newest deployment's `status` is `SUCCESS` (report deployed). If status is `FAILED` or `CRASHED`, triage per [operate.md](references/operate.md). If status is `NEEDS_APPROVAL`, `SLEEPING`, `SKIPPED`, `REMOVED`, `REMOVING`, or an unknown value, report the exact state and next action; do not claim success. A streaming `up` that exits on its own is authoritative: exit 0 = deployed, exit 1 = failed.
+1. Use Railway CLI for workflows that need the current repo, local shell, SSH, database scripts, local Railway context, or exact command output.
+2. Use Remote MCP for OAuth-scoped platform operations that match an available MCP tool and do not need local files or CLI state.
+3. Use local CLI MCP only when the current agent already has it explicitly configured and it exposes a needed operation not available through Remote MCP.
+4. Fall back to `scripts/railway-api.sh` for operations neither MCP nor CLI exposes.
+5. Use `--json` output where available for reliable parsing.
+6. Resolve context before mutation. Know which project, environment, and service you're acting on.
+7. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
+8. After mutations, verify the result with a read-back command or MCP read.
+9. **Never report a deploy as successful without observing a terminal SUCCESS.** `railway up --detach` returning (it prints "Build queued") and a streaming `railway up` cut off by a shell timeout only confirm the build *started*. Poll `railway deployment list --json` with the same `--project`, `--environment`, and `--service` scope used for the deploy until the newest deployment's `status` is `SUCCESS` (report deployed). If status is `FAILED` or `CRASHED`, triage per [operate.md](references/operate.md). If status is `NEEDS_APPROVAL`, `SLEEPING`, `SKIPPED`, `REMOVED`, `REMOVING`, or an unknown value, report the exact state and next action; do not claim success. A streaming `up` that exits on its own is authoritative: exit 0 = deployed, exit 1 = failed.
 
 ## User-only commands (NEVER execute directly)
 


### PR DESCRIPTION
## Summary

- Point all published Railway plugin MCP configs at the hosted Railway MCP server (`https://mcp.railway.com`) for single-click setup.
- Keep Claude/Codex, Cursor, and Grok MCP config files aligned on HTTP transport.
- Bump Railway plugin manifests to `1.3.4` and update plugin/marketplace copy to describe the hosted MCP server.
- Update skill and repo authoring guidance so the hosted MCP is the default plugin path, with CLI/local MCP reserved for explicit local workflows.

## Validation

- `python3 -m json.tool` on plugin MCP configs, plugin manifests, and marketplace JSON files
- `git diff --check`
- Marketplace catalog validation and plugin index generation/check for the xAI marketplace pin
