### PR TITLE
feat(use-railway): Railway feature flags agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ References:
 | Create or connect resources | `references/setup.md` | Projects, services, databases, buckets, templates, workspaces |
 | Ship code or manage releases | `references/deploy.md` | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | `references/configure.md` | Environments, variables, config patches, domains, networking |
+| Manage feature flags | `references/feature-flags.md` | MCP list/get/set/delete; dashboard for rules; SDK runtime reads |
 | Define or import project configuration as code | `references/iac.md` | Railway IaC, `.railway/railway.ts`, config init/pull/plan/apply, drift checks |
 | Check health or debug failures | `references/operate.md` | Status, logs, metrics, build/runtime triage, recovery |
 | Use a sandbox or build remotely | `references/sandbox.md` | Sandboxes: create/fork, remote exec, remote template builds, checkpoints, port forwarding (requires Priority Boarding) |
@@ -47,7 +48,7 @@ References:
 Choose the Railway operation path that matches the job.
 
 - Railway CLI (`railway`): local-machine workflows such as current-directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, and exact command output.
-- Remote MCP (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment status, bounded logs, simple redeploys, simple project creation, and complex workflows through `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
+- Remote MCP (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment status, feature flags, bounded logs, simple redeploys, simple project creation, and complex workflows through `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
 - GraphQL: operations that neither MCP nor CLI exposes.
 
 Optional: if the current agent already has a user-installed local CLI MCP (`railway mcp`) configured, it can be used for CLI-backed platform operations not yet exposed by remote MCP. Published plugin configs do not install or launch local CLI MCP.

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using Railway skills and the hosted MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -4,8 +4,9 @@ description: >
   Operate Railway infrastructure: sign up for or sign in to a Railway account,
   create projects, provision services and databases, manage object storage
   buckets, deploy code, configure environments and variables, manage domains,
-  troubleshoot failures, check status and metrics, set up Railway agent tooling,
-  and query Railway docs. Use this skill whenever the user mentions Railway,
+  troubleshoot failures, check status and metrics, manage feature flags,
+  set up Railway agent tooling, and query Railway docs. Use this skill whenever
+  the user mentions Railway, feature flags, flag rollout, targeting rules,
   signing up, creating an account, registering, logging in, deployments,
   services, environments, buckets, object storage, build failures, agent setup,
   MCP, or infrastructure operations, even if they don't say "Railway" explicitly.
@@ -36,7 +37,7 @@ Most CLI commands operate on the linked project/environment/service context. Use
 Railway has three agent-facing operation paths. Choose the path that matches the job:
 
 - **Railway CLI** (`railway`): workflows that depend on local machine state such as current working directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, or exact command output.
-- **Remote MCP** (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment state, bounded logs, simple redeploys, simple project creation, or complex Railway workflows that can be handed to `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
+- **Remote MCP** (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment state, bounded logs, feature flags, simple redeploys, simple project creation, or complex Railway workflows that can be handed to `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
 - **GraphQL**: operations that neither MCP nor CLI exposes, or when a reference gives a specific GraphQL fallback.
 
 If multiple paths are available, choose the one that preserves the needed context. The CLI fits workflows that need the current repo, local credentials, SSH, database scripts, or exact command output. Remote MCP fits OAuth-scoped platform operations that do not need local files or CLI state.
@@ -98,7 +99,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.4" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.5" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -122,7 +123,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.4` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.5` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.
@@ -279,6 +280,7 @@ For anything beyond quick operations, load the reference that matches the user's
 | Create or connect resources | [setup.md](references/setup.md) | Projects, services, databases, buckets, templates, workspaces |
 | Ship code or manage releases | [deploy.md](references/deploy.md) | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | [configure.md](references/configure.md) | Environments, variables, config patches, domains, networking |
+| Manage feature flags | [feature-flags.md](references/feature-flags.md) | List/create/update project flags via MCP; workspace flags read-only; SDK runtime reads |
 | Define or import project configuration as code ("IaC", "infrastructure as code", ".railway/railway.ts", "config plan/apply/pull") | [iac.md](references/iac.md) | Project-level Railway configuration files, import, plan, apply, drift checks, destructive apply safety |
 | Check health or debug failures | [operate.md](references/operate.md) | Status, logs, metrics, build/runtime triage, recovery |
 | Use a sandbox or build remotely ("sandbox", "scratch environment", "ephemeral box", "build remotely", "remote build", "run this remotely", "checkpoint", "snapshot/save/restore sandbox state") | [sandbox.md](references/sandbox.md) | Create/fork sandboxes, run commands remotely, remote template builds, checkpoints (save/restore sandbox state), port forwarding, teardown. Requires Sandboxes enabled in Priority Boarding — if unavailable, prompt the user to enable it. |

--- a/plugins/railway/skills/use-railway/references/configure.md
+++ b/plugins/railway/skills/use-railway/references/configure.md
@@ -40,7 +40,6 @@ Use stdin for secrets or values that shouldn't appear in shell history:
 
 ```bash
 printf "%s" "$SECRET_VALUE" | railway variable set API_KEY --stdin --service <service>
-railway variable set FEATURE_FLAG=true --service <service> --skip-deploys
 railway variable set API_URL=https://api.example.com --project <project-id> --environment <env> --service <service>
 ```
 

--- a/plugins/railway/skills/use-railway/references/feature-flags.md
+++ b/plugins/railway/skills/use-railway/references/feature-flags.md
@@ -1,0 +1,89 @@
+# Feature flags
+
+Manage Railway feature flags (Signals): typed defaults, targeting rules, and runtime reads via the SDK or GraphQL.
+
+## What they are
+
+Railway feature flags are **project- or workspace-scoped** configuration values resolved at read time from a registry (not environment variables). Each flag has:
+
+- A **type**: `bool`, `string`, `number`, or `json`
+- A **default** value used when no rule matches
+- Optional **targeting rules** (attribute comparisons and rollout percentages)
+
+Project flags are managed in **Project Settings → Feature Flags**. Workspace flags are visible there read-only.
+
+Runtime apps read **one scope** at a time (`project:<id>` or `workspace:<id>`) via the [TypeScript SDK](https://github.com/railwayapp/railway-ts-sdk) or GraphQL — flags from other scopes are separate registries.
+
+## Agent / MCP workflow
+
+Prefer **Remote MCP** tools when OAuth-scoped project access is enough:
+
+| Tool | Access | Purpose |
+|---|---|---|
+| `list-feature-flags` | viewer | List project flags; includes workspace flags when present |
+| `get-feature-flag` | viewer | Inspect one flag (`scope`: `project` or `workspace`) |
+| `set-feature-flag` | admin | Create a flag or update its default |
+| `delete-feature-flag` | admin | Delete a project-scoped flag |
+
+Always pass explicit `projectId` (from a Railway URL or `railway status --json`).
+
+```text
+List feature flags for project 6adb5ae3-0e3a-4ead-b42c-1fd36f217ffb
+```
+
+```text
+Set feature flag checkout-v2 on project 6adb5ae3-0e3a-4ead-b42c-1fd36f217ffb to true (bool)
+```
+
+For targeting rules and rollouts, use the dashboard UI or GraphQL (`signalRuleSet`) until MCP rule tools exist.
+
+## CLI (when available)
+
+The Railway CLI exposes `railway flag` (alias `railway signal`) for registry CRUD. Upgrade the CLI if the command is missing:
+
+```bash
+railway upgrade --yes
+railway flag list --project <project-id> --json
+railway flag checkout-v2 true --project <project-id>
+```
+
+Use `--project` (or link first) so scope is explicit in agent workflows.
+
+## GraphQL fallback
+
+When MCP and CLI are unavailable, use the public GraphQL API (`signals`, `signalCreate`, `signalDefaultSet`, `signalRuleSet`, `signalDelete`) with owner `project:<projectId>` or `workspace:<workspaceId>`. See https://docs.railway.com/docs/feature-flags
+
+```bash
+scripts/railway-api.sh '{"owner":"project:<projectId>"}' <<'EOF'
+query projectSignals($owner: String!) {
+  signals(owner: $owner) { name type default rules version }
+}
+EOF
+```
+
+## Runtime SDK
+
+In deployed services, use the Railway SDK flags module:
+
+```typescript
+import { flags } from "railway";
+
+await flags.init({ scope: { projectId: process.env.RAILWAY_PROJECT_ID! } });
+
+const enabled = flags.getBoolean("checkout-v2", {
+  targetingKey: userId,
+  attributes: { plan: "enterprise" },
+});
+```
+
+Poll interval defaults are suitable for most apps; flags refresh when registry versions change.
+
+## Do not confuse with
+
+- **Environment variables** — static per-environment config (`railway variable set`). Use flags when you need typed defaults, targeting, and central registry semantics.
+- **Priority Boarding / account toggles** — internal beta switches on your Railway account, unrelated to project feature flags.
+- **Platform feature flags** — Railway staff tooling only.
+
+## Dashboard
+
+Human-friendly CRUD: open the project → **Settings → Feature Flags**. Workspace-scoped flags appear in a read-only section when they exist.


### PR DESCRIPTION
## Summary
- Add `references/feature-flags.md` with MCP-first workflow for Railway Signals
- Route feature flag intents in `use-railway` skill + AGENTS.md
- Remove misleading `FEATURE_FLAG=true` env var example from configure reference
- Bump plugin version to 1.3.5

## Test plan
- [x] `railway skills update` picks up new reference
- [ ] Agent asking to list/create flags loads feature-flags.md


Made with [Cursor](https://cursor.com)