### PR TITLE
feat(use-railway): prefer RAILWAY_TOKEN project tokens in flags SDK guidance

### DIFF
--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using Railway skills and the hosted MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -99,7 +99,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.5" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.6" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -123,7 +123,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.5` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.6` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.

--- a/plugins/railway/skills/use-railway/references/feature-flags.md
+++ b/plugins/railway/skills/use-railway/references/feature-flags.md
@@ -63,17 +63,23 @@ EOF
 
 ## Runtime SDK
 
-In deployed services, use the Railway SDK flags module:
+In deployed services, use the Railway SDK flags module. Recommended setup: create a project token (project settings → Tokens) and set it as `RAILWAY_TOKEN` on the service — init is then zero-config and the scope is inferred from the token:
 
 ```typescript
 import { flags } from "railway";
 
-await flags.init({ scope: { projectId: process.env.RAILWAY_PROJECT_ID! } });
+await flags.init();
 
 const enabled = flags.getBoolean("checkout-v2", {
   targetingKey: userId,
   attributes: { plan: "enterprise" },
 });
+```
+
+Token resolution: explicit `token` option → `RAILWAY_TOKEN` (project token, preferred) → `RAILWAY_API_TOKEN` (bearer account/workspace token, last resort). With a bearer token, pass the scope explicitly:
+
+```typescript
+await flags.init({ scope: { projectId: process.env.RAILWAY_PROJECT_ID! } });
 ```
 
 Poll interval defaults are suitable for most apps; flags refresh when registry versions change.


### PR DESCRIPTION
## Summary
- Feature flags reference now recommends a project token in `RAILWAY_TOKEN` with zero-config `flags.init()` (scope inferred from the token)
- Documents token resolution order with bearer `RAILWAY_API_TOKEN` as last resort
- Plugin version bumped to 1.3.6

Pairs with railway-ts-sdk#50.

## Test plan
- [ ] `railway skills update` picks up 1.3.6
- [ ] Agent asked about flags at runtime suggests project token setup first


Made with [Cursor](https://cursor.com)