### PR TITLE
fix(railway): support current GraphQL credentials

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  railway-api-helper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test GraphQL helper authentication
+        run: python3 tests/railway_api_test.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,12 @@ Use GraphQL for operations the CLI doesn't expose.
 - API helper: `plugins/railway/skills/use-railway/scripts/railway-api.sh`
 - The API helper attaches `X-Railway-Skill-Id`, `X-Railway-Skill-Version`, and `X-Railway-Agent-Session` headers.
 
-### API token
+### GraphQL helper authentication
 
-Token location: `~/.railway/config.json` under `user.token`.
+For GraphQL fallbacks, prefer an explicit `RAILWAY_API_TOKEN` for account or
+workspace scope, or `RAILWAY_TOKEN` for project scope. The helper otherwise
+uses an unexpired browser-login `user.accessToken` and retains legacy
+`user.token` compatibility. It does not read or refresh `user.refreshToken`.
 
 Example:
 
@@ -98,6 +101,7 @@ API docs: https://docs.railway.com/api/llms-docs.md
 When editing this plugin:
 
 - Keep `SKILL.md` focused on routing, preflight, composition, and common operations.
+- Run `python3 tests/railway_api_test.py` when changing the GraphQL helper.
 - Keep references organized by information type (setup, deploy, configure, iac, operate, api).
 - Keep references action-oriented with reasoning. Explain why, not only what.
 - Keep CLI behavior claims aligned with Railway docs and CLI source.

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using Railway skills and the hosted MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -99,7 +99,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.5" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.6" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -123,7 +123,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.5` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.6` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.

--- a/plugins/railway/skills/use-railway/references/request.md
+++ b/plugins/railway/skills/use-railway/references/request.md
@@ -85,13 +85,30 @@ Community threads are anecdotal. Always pair with official docs when the answer 
 
 ## GraphQL helper
 
-All GraphQL operations use the API helper script, which handles authentication automatically:
+Use GraphQL only when neither the Railway CLI nor MCP exposes the required
+operation. All GraphQL operations use the API helper script:
 
 ```bash
 scripts/railway-api.sh '<query>' '<variables-json>'
 ```
 
-The script reads the API token from `~/.railway/config.json` and sends requests to `https://backboard.railway.com/graphql/v2`.
+The helper sends requests to `https://backboard.railway.com/graphql/v2` and
+uses these credential paths in order:
+
+1. `RAILWAY_API_TOKEN` for an account or workspace token, sent as
+   `Authorization: Bearer`.
+2. `RAILWAY_TOKEN` for a project token, sent as `Project-Access-Token`.
+3. The current browser-login access token in
+   `~/.railway/config.json:user.accessToken`, sent as Bearer when it is not
+   expired.
+4. The legacy `~/.railway/config.json:user.token`, sent as Bearer.
+
+Set only one explicit token variable. The helper never reads or refreshes
+`user.refreshToken`; Railway CLI owns the OAuth refresh lifecycle. If the
+stored access token is expired, run a Railway CLI command or `railway login`
+before retrying. An access token with a missing or invalid expiry also fails
+with that guidance. Credentials are not printed or passed as curl header
+arguments.
 
 For the full API schema, see: https://docs.railway.com/api/llms-docs.md
 

--- a/plugins/railway/skills/use-railway/scripts/railway-api.sh
+++ b/plugins/railway/skills/use-railway/scripts/railway-api.sh
@@ -5,7 +5,7 @@
 set -e
 
 SKILL_ID="use-railway"
-SKILL_VERSION="${RAILWAY_SKILL_VERSION:-1.2.3}"
+SKILL_VERSION="${RAILWAY_SKILL_VERSION:-1.3.6}"
 
 export RAILWAY_CALLER="${RAILWAY_CALLER:-skill:${SKILL_ID}@${SKILL_VERSION}}"
 export RAILWAY_AGENT_SESSION="${RAILWAY_AGENT_SESSION:-railway-skill-$(date +%s)-$$}"
@@ -17,16 +17,52 @@ fi
 
 CONFIG_FILE="$HOME/.railway/config.json"
 
-if [[ ! -f "$CONFIG_FILE" ]]; then
-  echo '{"error": "Railway config not found. Run: railway login"}'
+if [[ -n "${RAILWAY_API_TOKEN:-}" && -n "${RAILWAY_TOKEN:-}" ]]; then
+  echo '{"error": "RAILWAY_API_TOKEN and RAILWAY_TOKEN cannot both be set"}'
   exit 1
 fi
 
-TOKEN=$(jq -r '.user.token' "$CONFIG_FILE")
+TOKEN=""
+AUTH_HEADER=""
 
-if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
-  echo '{"error": "No Railway token found. Run: railway login"}'
-  exit 1
+if [[ -n "${RAILWAY_API_TOKEN:-}" ]]; then
+  TOKEN="$RAILWAY_API_TOKEN"
+  AUTH_HEADER="Authorization: Bearer $TOKEN"
+elif [[ -n "${RAILWAY_TOKEN:-}" ]]; then
+  TOKEN="$RAILWAY_TOKEN"
+  AUTH_HEADER="Project-Access-Token: $TOKEN"
+else
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo '{"error": "Railway config not found. Run: railway login or set RAILWAY_API_TOKEN or RAILWAY_TOKEN"}'
+    exit 1
+  fi
+
+  ACCESS_TOKEN=$(jq -r '.user.accessToken // empty' "$CONFIG_FILE")
+
+  if [[ -n "$ACCESS_TOKEN" ]]; then
+    ACCESS_TOKEN_EXPIRES_AT=$(jq -r '.user.tokenExpiresAt // empty' "$CONFIG_FILE")
+
+    if [[ ! "$ACCESS_TOKEN_EXPIRES_AT" =~ ^[0-9]+$ ]]; then
+      echo '{"error": "Railway access token has no valid expiry. Run a Railway CLI command or railway login to refresh it, then retry."}'
+      exit 1
+    fi
+
+    if (( ACCESS_TOKEN_EXPIRES_AT <= $(date +%s) + 60 )); then
+      echo '{"error": "Railway access token is expired. Run a Railway CLI command or railway login to refresh it, then retry."}'
+      exit 1
+    fi
+
+    TOKEN="$ACCESS_TOKEN"
+  else
+    TOKEN=$(jq -r '.user.token // empty' "$CONFIG_FILE")
+  fi
+
+  if [[ -z "$TOKEN" ]]; then
+    echo '{"error": "No Railway credential found. Run: railway login or set RAILWAY_API_TOKEN or RAILWAY_TOKEN"}'
+    exit 1
+  fi
+
+  AUTH_HEADER="Authorization: Bearer $TOKEN"
 fi
 
 if [[ -z "$1" ]]; then
@@ -41,8 +77,20 @@ else
   PAYLOAD=$(jq -n --arg q "$1" '{query: $q}')
 fi
 
+ORIGINAL_UMASK=$(umask)
+umask 077
+AUTH_HEADER_FILE=$(mktemp "${TMPDIR:-/tmp}/railway-api-header.XXXXXX")
+umask "$ORIGINAL_UMASK"
+
+cleanup() {
+  rm -f "$AUTH_HEADER_FILE"
+}
+
+trap cleanup EXIT
+printf '%s\n' "$AUTH_HEADER" > "$AUTH_HEADER_FILE"
+
 HEADERS=(
-  -H "Authorization: Bearer $TOKEN"
+  -H "@$AUTH_HEADER_FILE"
   -H "Content-Type: application/json"
   -H "X-Railway-Skill-Id: $SKILL_ID"
   -H "X-Railway-Skill-Version: $SKILL_VERSION"

--- a/tests/railway_api_test.py
+++ b/tests/railway_api_test.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Black-box regression tests for the Railway GraphQL helper.
+
+The helper is invoked exactly as a skill caller invokes it.  A fake curl binary
+records options and header-file contents, so no credential or network request
+leaves the test process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import time
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELPER = REPO_ROOT / "plugins/railway/skills/use-railway/scripts/railway-api.sh"
+QUERY = "query { project { id } }"
+
+FAKE_CURL = """#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+arguments = sys.argv[1:]
+headers = []
+for index, argument in enumerate(arguments):
+    if argument == "-H":
+        header = arguments[index + 1]
+        if header.startswith("@"):
+            headers.extend(
+                line for line in Path(header[1:]).read_text().splitlines() if line
+            )
+        else:
+            headers.append(header)
+
+Path(os.environ["TEST_CAPTURE_PATH"]).write_text(
+    json.dumps({"arguments": arguments, "headers": headers})
+)
+print('{"data":{"ok":true}}')
+"""
+
+FAKE_RAILWAY = """#!/usr/bin/env python3
+import os
+from pathlib import Path
+
+Path(os.environ["TEST_RAILWAY_INVOKED_PATH"]).write_text("invoked")
+raise SystemExit(1)
+"""
+
+
+class RailwayApiHelperTests(unittest.TestCase):
+    def run_helper(self, *, config=None, api_token=None, project_token=None):
+        with tempfile.TemporaryDirectory() as directory:
+            temp_dir = Path(directory)
+            home = temp_dir / "home"
+            curl_dir = temp_dir / "bin"
+            capture_path = temp_dir / "capture.json"
+            curl_dir.mkdir(parents=True)
+            fake_curl = curl_dir / "curl"
+            fake_curl.write_text(FAKE_CURL)
+            fake_curl.chmod(0o755)
+            fake_railway = curl_dir / "railway"
+            fake_railway.write_text(FAKE_RAILWAY)
+            fake_railway.chmod(0o755)
+            railway_invoked_path = temp_dir / "railway-invoked"
+
+            if config is not None:
+                config_path = home / ".railway/config.json"
+                config_path.parent.mkdir(parents=True)
+                config_path.write_text(json.dumps(config))
+
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "HOME": str(home),
+                    "PATH": f"{curl_dir}:{environment['PATH']}",
+                    "TEST_CAPTURE_PATH": str(capture_path),
+                    "TEST_RAILWAY_INVOKED_PATH": str(railway_invoked_path),
+                }
+            )
+            environment.pop("RAILWAY_API_TOKEN", None)
+            environment.pop("RAILWAY_TOKEN", None)
+            if api_token is not None:
+                environment["RAILWAY_API_TOKEN"] = api_token
+            if project_token is not None:
+                environment["RAILWAY_TOKEN"] = project_token
+
+            completed = subprocess.run(
+                [str(HELPER), QUERY],
+                cwd=REPO_ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            capture = (
+                json.loads(capture_path.read_text()) if capture_path.exists() else None
+            )
+            return completed, capture, railway_invoked_path.exists()
+
+    def assert_success_header(
+        self, completed, capture, railway_invoked, expected_header, token
+    ):
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(json.loads(completed.stdout), {"data": {"ok": True}})
+        self.assertIsNotNone(capture)
+        self.assertIn(expected_header, capture["headers"])
+        self.assertNotIn(token, " ".join(capture["arguments"]))
+        self.assertFalse(railway_invoked)
+
+    def test_current_oauth_access_token_uses_bearer_without_refreshing(self):
+        token = "fixture-oauth-access-token"
+        completed, capture, railway_invoked = self.run_helper(
+            config={
+                "user": {
+                    "accessToken": token,
+                    "refreshToken": "fixture-refresh-token",
+                    "tokenExpiresAt": int(time.time()) + 3600,
+                }
+            }
+        )
+
+        self.assert_success_header(
+            completed, capture, railway_invoked, f"Authorization: Bearer {token}", token
+        )
+        observed = completed.stdout + completed.stderr + " ".join(
+            capture["arguments"] + capture["headers"]
+        )
+        self.assertNotIn("fixture-refresh-token", observed)
+
+    def test_legacy_config_token_remains_compatible(self):
+        token = "fixture-legacy-token"
+        completed, capture, railway_invoked = self.run_helper(
+            config={"user": {"token": token}}
+        )
+
+        self.assert_success_header(
+            completed, capture, railway_invoked, f"Authorization: Bearer {token}", token
+        )
+
+    def test_explicit_account_or_workspace_token_does_not_require_config(self):
+        token = "fixture-account-token"
+        completed, capture, railway_invoked = self.run_helper(api_token=token)
+
+        self.assert_success_header(
+            completed, capture, railway_invoked, f"Authorization: Bearer {token}", token
+        )
+
+    def test_explicit_project_token_uses_project_access_token_header(self):
+        token = "fixture-project-token"
+        completed, capture, railway_invoked = self.run_helper(project_token=token)
+
+        self.assert_success_header(
+            completed,
+            capture,
+            railway_invoked,
+            f"Project-Access-Token: {token}",
+            token,
+        )
+        self.assertFalse(
+            any(header.startswith("Authorization:") for header in capture["headers"])
+        )
+
+    def test_mutually_exclusive_explicit_tokens_fail_without_request(self):
+        completed, capture, railway_invoked = self.run_helper(
+            api_token="fixture-account-token", project_token="fixture-project-token"
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("cannot both be set", completed.stdout)
+        self.assertIsNone(capture)
+        self.assertFalse(railway_invoked)
+
+    def test_missing_credentials_fail_without_request(self):
+        completed, capture, railway_invoked = self.run_helper(config={"user": {}})
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("No Railway credential found", completed.stdout)
+        self.assertIsNone(capture)
+        self.assertFalse(railway_invoked)
+
+    def test_refresh_token_is_never_used_as_a_credential(self):
+        completed, capture, railway_invoked = self.run_helper(
+            config={"user": {"refreshToken": "fixture-refresh-token"}}
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("No Railway credential found", completed.stdout)
+        self.assertIsNone(capture)
+        self.assertFalse(railway_invoked)
+
+    def test_expired_access_token_fails_without_refreshing_or_requesting(self):
+        completed, capture, railway_invoked = self.run_helper(
+            config={
+                "user": {
+                    "accessToken": "fixture-expired-access-token",
+                    "refreshToken": "fixture-refresh-token",
+                    "tokenExpiresAt": int(time.time()) - 1,
+                }
+            }
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("expired", completed.stdout)
+        self.assertIsNone(capture)
+        self.assertFalse(railway_invoked)
+
+    def test_access_token_without_a_valid_expiry_fails_predictably(self):
+        completed, capture, railway_invoked = self.run_helper(
+            config={"user": {"accessToken": "fixture-access-token"}}
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("valid expiry", completed.stdout)
+        self.assertIsNone(capture)
+        self.assertFalse(railway_invoked)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary

- Restore the GraphQL helper for current Railway CLI OAuth config while supporting documented account/workspace and project tokens.
- Keep credentials out of curl's argument vector and add automated regression coverage for credential selection and expiry behavior.

## Motivation

Railway CLI browser login now persists an OAuth access token with an expiry, while the GraphQL helper only recognized the retired legacy token field. This left GraphQL-only skill operations unable to authenticate even when the CLI was signed in. Automation also needs the helper to distinguish account/workspace tokens from project tokens because Railway documents different request headers for each scope.

## Implementation Details

- `RAILWAY_API_TOKEN` uses `Authorization: Bearer`; `RAILWAY_TOKEN` uses `Project-Access-Token`; setting both produces a redacted error.
- Browser-login fallback reads only an unexpired `user.accessToken`, retains legacy `user.token`, and does not read or refresh `user.refreshToken` or invoke Railway CLI.
- The helper writes its auth header to a mode-`0600` temporary file, removes it on exit, and keeps that secret out of curl's process arguments.
- Align plugin/helper telemetry versions at 1.3.6 and document the supported GraphQL credential paths.

## Linked Issues

- Closes #33
