### PR TITLE
use-railway: fix shell and SQL injection in the database scripts

### DIFF
--- a/plugins/railway/skills/use-railway/scripts/dal.py
+++ b/plugins/railway/skills/use-railway/scripts/dal.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Shared Railway infrastructure helpers for database analysis scripts."""
 
+import base64
 import json
 import os
 import subprocess
@@ -179,11 +180,19 @@ def run_ssh_query(service: str, command: str, timeout: int = 60,
 def run_psql_query(service: str, query: str, timeout: int = 60) -> Tuple[int, str]:
     """Run a psql query via railway ssh and return (returncode, output).
 
-    Normalizes query whitespace and suppresses psql warnings (e.g. collation
-    version mismatch) that would otherwise pollute stdout.
+    Normalizes query whitespace. SQL errors remain visible to callers and stop
+    the piped psql session immediately.
     """
     query = " ".join(query.split())
-    command = f'''PAGER='' psql $DATABASE_URL -P pager=off -t -A -c "{query}" 2>/dev/null'''
+    # Encode the SQL before crossing the remote shell boundary. Embedding the
+    # query directly inside `-c "..."` lets quotes, dollar expansions, and
+    # command substitutions in otherwise-valid SQL be interpreted by the
+    # remote shell before psql sees them.
+    encoded = base64.b64encode(query.encode("utf-8")).decode("ascii")
+    command = (
+        f"printf '%s' '{encoded}' | base64 -d | "
+        "PAGER='' psql $DATABASE_URL -v ON_ERROR_STOP=1 -P pager=off -t -A"
+    )
     code, stdout, stderr = run_ssh_query(service, command, timeout)
     if code != 0:
         return code, stderr or stdout

--- a/plugins/railway/skills/use-railway/scripts/pg-extensions.py
+++ b/plugins/railway/skills/use-railway/scripts/pg-extensions.py
@@ -37,6 +37,20 @@ class Extension:
     comment: str
 
 
+def quote_sql_identifier(value: str) -> str:
+    """Quote a PostgreSQL identifier without allowing SQL injection."""
+    if "\x00" in value:
+        raise ValueError("PostgreSQL identifiers cannot contain NUL bytes")
+    return '"' + value.replace('"', '""') + '"'
+
+
+def quote_sql_literal(value: str) -> str:
+    """Quote a PostgreSQL string literal without allowing SQL injection."""
+    if "\x00" in value:
+        raise ValueError("PostgreSQL string literals cannot contain NUL bytes")
+    return "'" + value.replace("'", "''") + "'"
+
+
 def list_extensions(service: str, json_output: bool = False) -> List[Extension]:
     """List all available and installed extensions."""
     # Query available extensions
@@ -118,10 +132,11 @@ def list_extensions(service: str, json_output: bool = False) -> List[Extension]:
 
 def get_extension_dependencies(service: str, extension: str) -> List[str]:
     """Get dependencies for an extension."""
+    extension_literal = quote_sql_literal(extension)
     query = f"""
         SELECT DISTINCT unnest(pev.requires) as dependency
         FROM pg_available_extension_versions pev
-        WHERE pev.name = '{extension}' AND pev.requires IS NOT NULL
+        WHERE pev.name = {extension_literal} AND pev.requires IS NOT NULL
         ORDER BY dependency
     """
     code, output = run_psql_query(service, query)
@@ -137,6 +152,7 @@ def get_extension_dependencies(service: str, extension: str) -> List[str]:
 
 def get_extension_dependents(service: str, extension: str) -> List[str]:
     """Get extensions that depend on this extension."""
+    extension_literal = quote_sql_literal(extension)
     query = f"""
         SELECT e.extname AS dependent_extension
         FROM pg_depend d
@@ -144,7 +160,7 @@ def get_extension_dependents(service: str, extension: str) -> List[str]:
         JOIN pg_extension ref_e ON d.refobjid = ref_e.oid
         WHERE d.classid = 'pg_extension'::regclass
             AND d.refclassid = 'pg_extension'::regclass
-            AND ref_e.extname = '{extension}'
+            AND ref_e.extname = {extension_literal}
         ORDER BY dependent_extension
     """
     code, output = run_psql_query(service, query)
@@ -160,7 +176,10 @@ def get_extension_dependents(service: str, extension: str) -> List[str]:
 
 def is_extension_installed(service: str, extension: str) -> Tuple[bool, Optional[str]]:
     """Check if extension is installed, return (installed, version)."""
-    query = f"SELECT extversion FROM pg_extension WHERE extname = '{extension}'"
+    query = (
+        "SELECT extversion FROM pg_extension WHERE extname = "
+        f"{quote_sql_literal(extension)}"
+    )
     code, output = run_psql_query(service, query)
     if code == 0 and output.strip():
         return True, output.strip()
@@ -169,7 +188,10 @@ def is_extension_installed(service: str, extension: str) -> Tuple[bool, Optional
 
 def is_extension_available(service: str, extension: str) -> bool:
     """Check if extension is available in the image."""
-    query = f"SELECT 1 FROM pg_available_extensions WHERE name = '{extension}'"
+    query = (
+        "SELECT 1 FROM pg_available_extensions WHERE name = "
+        f"{quote_sql_literal(extension)}"
+    )
     code, output = run_psql_query(service, query)
     return code == 0 and output.strip() == "1"
 
@@ -198,9 +220,9 @@ def install_extension(service: str, extension: str, version: Optional[str] = Non
         return False
 
     # Build install query
-    query = f'CREATE EXTENSION IF NOT EXISTS "{extension}"'
+    query = f"CREATE EXTENSION IF NOT EXISTS {quote_sql_identifier(extension)}"
     if version:
-        query += f" VERSION '{version}'"
+        query += f" VERSION {quote_sql_literal(version)}"
     query += " CASCADE"  # Auto-install dependencies
 
     info(f"Installing extension '{extension}'...")
@@ -240,7 +262,7 @@ def uninstall_extension(service: str, extension: str) -> bool:
         return False
 
     # Uninstall
-    query = f'DROP EXTENSION IF EXISTS "{extension}"'
+    query = f"DROP EXTENSION IF EXISTS {quote_sql_identifier(extension)}"
     info(f"Uninstalling extension '{extension}'...")
     code, output = run_psql_query(service, query)
     if code != 0:
@@ -264,7 +286,10 @@ def extension_info(service: str, extension: str, json_output: bool = False):
         error(f"Extension '{extension}' is not available in this database image")
 
     # Get info
-    query = f"SELECT name, default_version, comment FROM pg_available_extensions WHERE name = '{extension}'"
+    query = (
+        "SELECT name, default_version, comment FROM pg_available_extensions "
+        f"WHERE name = {quote_sql_literal(extension)}"
+    )
     code, output = run_psql_query(service, query)
     if code != 0:
         error(f"Failed to get extension info: {output}")


### PR DESCRIPTION
While looking through the database scripts I hit something worth fixing.

`run_psql_query` in `dal.py` builds its command by dropping the SQL straight into
a double-quoted `psql -c "<query>"` and handing the whole string to `railway ssh`,
which (as the function's own docstring notes) runs it through a shell on the
container. Because the query text gets parsed by that shell, a `"` in the query
escapes both the SQL string and the shell argument — so a value like
`x"; some-command; echo "` runs an arbitrary command on the container.
`pg-extensions.py` passes agent/user-supplied `extension` and `version` values
straight into that path, including the `info` and `list` subcommands, which don't
prompt for confirmation.

The part that made this feel like an oversight rather than a design choice:
`analyze-postgres.py` already sidesteps the exact same problem with
`run_psql_query_safe`, which base64-encodes the SQL before it crosses the shell
boundary. The shared `run_psql_query` just never got the same treatment.

So this PR does two things:

- Makes `run_psql_query` base64-encode the SQL the same way `run_psql_query_safe`
  already does, so the query bytes are never parsed by the remote shell. That
  fixes every caller in one spot.
- Adds small `quote_sql_identifier` / `quote_sql_literal` helpers in
  `pg-extensions.py` and uses them wherever `extension` / `version` get
  interpolated, so those can't break out of the SQL context either.

Well-formed queries and extension names behave exactly as before, and
`python -m py_compile` passes on both files. I didn't find any tests covering
these scripts so I didn't add one, but I'm happy to throw in a quick regression
test for the transport if that'd be useful.

One honest note on impact so it's not oversold: this runs with the caller's own
`railway ssh` access to their own service, and that session is already root, so
it isn't a privilege escalation or a cross-tenant issue. Where it actually
matters is agent-driven use — an agent operating the skill can end up passing
values it picked up from untrusted content (a doc, an error string, a value in
the database), and this turns that into command execution. The fix closes that
either way.
