### PR TITLE
Consolidate Railway configuration guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ References:
 | Ship code or manage releases | `references/deploy.md` | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | `references/configure.md` | Environments, variables, config patches, domains, networking |
 | Manage feature flags | `references/feature-flags.md` | MCP list/get/set/delete; dashboard for rules; SDK runtime reads |
-| Define or import project configuration as code | `references/iac.md` | Railway IaC, `.railway/railway.ts`, config init/pull/plan/apply, drift checks |
+| Define configuration in source control | `references/iac.md` | TypeScript IaC selection, `.railway/railway.ts`, `railway.json` fallback, config init/pull/plan/apply, drift checks |
 | Check health or debug failures | `references/operate.md` | Status, logs, metrics, build/runtime triage, recovery |
 | Use a sandbox or build remotely | `references/sandbox.md` | Sandboxes: create/fork, remote exec, remote template builds, checkpoints, port forwarding (requires Priority Boarding) |
 | Analyze databases | `references/analyze-db.md` | Database introspection and performance analysis, then DB-specific refs |

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using Railway skills and the hosted MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -3,7 +3,7 @@ name: use-railway
 description: >
   Operate Railway infrastructure: sign up for or sign in to a Railway account,
   create projects, provision services and databases, manage object storage
-  buckets, deploy code, configure environments and variables, manage domains,
+  buckets, deploy code, configure infrastructure as code, environments and variables, manage domains,
   troubleshoot failures, check status and metrics, manage feature flags,
   set up Railway agent tooling, and query Railway docs. Use this skill whenever
   the user mentions Railway, feature flags, flag rollout, targeting rules,
@@ -99,7 +99,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.5" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.6" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -123,7 +123,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.5` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.6` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.
@@ -281,7 +281,7 @@ For anything beyond quick operations, load the reference that matches the user's
 | Ship code or manage releases | [deploy.md](references/deploy.md) | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | [configure.md](references/configure.md) | Environments, variables, config patches, domains, networking |
 | Manage feature flags | [feature-flags.md](references/feature-flags.md) | List/create/update project flags via MCP; workspace flags read-only; SDK runtime reads |
-| Define or import project configuration as code ("IaC", "infrastructure as code", ".railway/railway.ts", "config plan/apply/pull") | [iac.md](references/iac.md) | Project-level Railway configuration files, import, plan, apply, drift checks, destructive apply safety |
+| Define configuration in source control ("IaC", "infrastructure as code", "config as code", `.railway/railway.ts`, `railway.json`, "config plan/apply/pull") | [iac.md](references/iac.md) | Choose TypeScript IaC or the `railway.json` fallback, then author, import, plan, apply, or check drift safely |
 | Check health or debug failures | [operate.md](references/operate.md) | Status, logs, metrics, build/runtime triage, recovery |
 | Use a sandbox or build remotely ("sandbox", "scratch environment", "ephemeral box", "build remotely", "remote build", "run this remotely", "checkpoint", "snapshot/save/restore sandbox state") | [sandbox.md](references/sandbox.md) | Create/fork sandboxes, run commands remotely, remote template builds, checkpoints (save/restore sandbox state), port forwarding, teardown. Requires Sandboxes enabled in Priority Boarding — if unavailable, prompt the user to enable it. |
 | Request from API, docs, or community | [request.md](references/request.md) | Railway GraphQL API queries/mutations, metrics queries, Central Station, official docs |

--- a/plugins/railway/skills/use-railway/references/iac.md
+++ b/plugins/railway/skills/use-railway/references/iac.md
@@ -1,37 +1,149 @@
-# Infrastructure as Code
+# Configuration in source control
 
-Define, import, preview, and apply a Railway project from `.railway/railway.ts`.
+Choose one configuration model before editing files. Never manage the same service with both models.
 
-Use Railway IaC when the user wants project-level configuration in source control: services, databases, buckets, volumes, variables, replicas, domains, and canvas groups. Do not use it for a single-service deploy setting that is already owned by `railway.json` or `railway.toml`; migrate that service first so there is only one source of truth.
+## Choose the model
 
-## Files
+Prefer TypeScript Infrastructure as Code when the repository has TypeScript set up. Use `railway.json` only as the fallback for repositories without TypeScript.
 
-Railway IaC uses TypeScript:
+Use TypeScript IaC when any of these signals exist in the current project or workspace:
+
+- `.railway/railway.ts` already exists.
+- A `tsconfig.json` or another `tsconfig*.json` exists.
+- `package.json` declares `typescript`, or the project contains `.ts` or `.tsx` source files.
+
+If none of those signals exist, create or edit `railway.json`. Do not choose `railway.toml` for new agent-authored configuration.
+
+If a TypeScript repository already has `railway.json`, migrate the intended settings to `.railway/railway.ts` and remove the old file before planning. If the user explicitly asks to preserve the existing model rather than migrate, edit the existing file and explain that it remains service-level Config as Code.
+
+The models have different scopes:
+
+| Model | Scope | Applies when |
+|---|---|---|
+| `.railway/railway.ts` | Whole Railway project: services, databases, buckets, volumes, variables, replicas, domains, and canvas groups | `railway config apply` applies the reviewed project plan |
+| `railway.json` | One service's build and deploy settings | The next deployment reads the file; it does not update dashboard settings |
+
+## TypeScript Infrastructure as Code
+
+The desired Railway project state lives in:
 
 ```text
 .railway/railway.ts
-.railway/README.md
-.agents/skills/railway-config/SKILL.md
 ```
 
-`railway config init` and `railway config pull` create the support files when missing. The project-local `railway-config` skill helps future agents edit `.railway/railway.ts` safely.
+`railway config init` and `railway config pull` also create `.railway/README.md`. Railway agent setup installs the shared `use-railway` skill; config commands do not need or create a project-local skill.
 
-## Initialize or import
+### Core rules
+
+1. Express Railway product intent, not internal API details.
+2. Do not write Railway UUIDs into `.railway/railway.ts`.
+3. Do not write `EnvironmentConfigPatch`, `ServiceInstance`, Backboard internals, or generated Railway domains into source.
+4. Prefer helpers such as `service()`, `postgres()`, `redis()`, `mysql()`, `mongo()`, `bucket()`, `volume()`, `group()`, `github()`, and `image()`.
+5. Use `service.env.VARIABLE` and `database.env.VARIABLE` for references.
+6. Keep secrets out of source. Imported unknown secret values should use `preserve()` or be omitted when the user wants a smaller import.
+7. Prefer product DSL names such as `domains`, `replicas`, and `group`; avoid internal names such as `customDomains` and `multiRegionConfig`.
+8. Do not add platform defaults unless the user explicitly wants them.
+9. After editing `.railway/railway.ts`, run `railway config plan`.
+10. Do not run `railway config apply` unless the user explicitly asks.
+11. Never use `railway config apply --yes` or `--confirm-destructive` from an agent session without explicit user approval for the exact plan.
+
+### Initialize or import
 
 ```bash
-railway config init                         # create a starter .railway/railway.ts
+railway config init                         # create .railway/railway.ts
 railway config init --force                 # overwrite existing generated files
 railway config pull                         # import the linked project
 railway config pull --force                 # overwrite existing .railway/railway.ts
+railway config pull --omit-preserved-variables # omit unknown variable values
 railway config pull --json                  # print current graph instead of writing files
 railway config pull --agent                 # ask an agent to clean the import afterward
 ```
 
-If the directory is not linked, the CLI prompts for project/environment in an interactive terminal. In agent workflows, prefer linking first or passing explicit project/environment context when the CLI supports it.
+If the directory is not linked, the CLI prompts for project and environment in an interactive terminal. In agent workflows, link first or pass explicit project and environment context when supported.
 
-## Plan
+### Authoring
 
-Always plan before applying:
+Import the helpers needed by the project:
+
+```ts
+import {
+  bucket,
+  defineRailway,
+  github,
+  group,
+  image,
+  mongo,
+  mysql,
+  postgres,
+  preserve,
+  project,
+  redis,
+  service,
+  volume,
+} from "railway/iac";
+```
+
+Common resource patterns:
+
+```ts
+const db = postgres("postgres");
+
+const api = service("api", {
+  source: github("owner/repo", { branch: "main" }),
+  build: "pnpm build",
+  start: "pnpm start",
+  env: {
+    DATABASE_URL: db.env.DATABASE_URL,
+    INTERNAL_TOKEN: preserve(),
+  },
+  domains: ["api.example.com"],
+  replicas: 3,
+  volumeMounts: {
+    "/data": volume("uploads", { sizeMB: 4096 }),
+  },
+});
+
+const worker = service("worker", {
+  source: image("ghcr.io/acme/worker:latest"),
+  env: {
+    API_HOST: api.env.RAILWAY_PRIVATE_DOMAIN,
+    API_TOKEN: api.env.INTERNAL_TOKEN,
+  },
+});
+
+const media = bucket("media", { region: "iad" });
+const backend = group("Backend", [api, worker, db]);
+```
+
+Advanced placement can map regions to replica counts:
+
+```ts
+const web = service("web", {
+  replicas: {
+    "us-west2": 2,
+    "europe-west4": 1,
+  },
+});
+```
+
+Return every managed resource from the project:
+
+```ts
+export default defineRailway(() => {
+  const db = postgres("postgres");
+  const web = service("web", {
+    env: { DATABASE_URL: db.env.DATABASE_URL },
+  });
+
+  return project("my-app", {
+    resources: [db, web],
+  });
+});
+```
+
+### Plan
+
+Always plan after editing and before applying:
 
 ```bash
 railway config plan
@@ -47,9 +159,9 @@ Plan output summarizes changes in Terraform style:
 Plan: 1 to add, 0 to change, 0 to destroy
 ```
 
-Variable values are redacted by default. Use `--show-values` only when the user is intentionally reviewing non-secret config or accepts the secret exposure risk. Use `--detailed-exit-code` for CI drift checks: exit `0` means no changes, exit `2` means changes are pending, and other non-zero exits are errors.
+Variable values are redacted by default. Use `--show-values` only when the user accepts the secret exposure risk. For CI drift checks, `--detailed-exit-code` returns `0` for no changes, `2` for pending changes, and another non-zero code for errors.
 
-## Apply
+### Apply
 
 ```bash
 railway config apply
@@ -58,51 +170,88 @@ railway config apply --yes --confirm-destructive
 railway config apply --json --yes --confirm-destructive
 ```
 
-`apply` always runs a fresh plan first. If the environment changed after the last plan, Railway rejects the apply and asks for a new plan. In non-interactive or agent sessions, destructive changes require `--confirm-destructive` in addition to `--yes` or `--json`; do not add it unless the user explicitly approved the destructive impact.
+`apply` runs a fresh plan. If remote state changed, Railway rejects the stale apply and requires another plan. In non-interactive or agent sessions, destructive changes require `--confirm-destructive` in addition to `--yes` or `--json`; add it only after the user explicitly approves the exact destructive impact.
 
-## Authoring pattern
+### Review checklist
 
-Keep `.railway/railway.ts` readable and explicit:
+Before applying, confirm:
 
-```ts
-import { defineRailway, project, service } from "railway/iac";
+- The latest plan shows only expected changes.
+- The user reviewed the plan and explicitly requested apply.
+- Secrets are not replaced with literal placeholders.
+- Existing Railway-managed variables are omitted or use `preserve()` when they should remain untouched.
+- Custom domains use `domains`, not networking internals.
+- Scaling uses `replicas`, not `multiRegionConfig`.
+- No generated Railway service domains or Railway UUIDs are committed.
 
-export default defineRailway(() => {
-  const web = service("web", {
-    build: "pnpm build",
-    start: "pnpm start",
-  });
+### Troubleshoot TypeScript IaC
 
-  return project("my-project", {
-    resources: [web],
-  });
-});
+- **Service is already managed by `railway.json`**: migrate its intended settings and remove the old file before planning; Railway blocks dual ownership.
+- **Plan shows secrets as hidden**: expected. Use `--show-values` only with user approval.
+- **Apply says the plan is stale**: run a new plan, inspect it, then apply again only if requested.
+- **Destructive apply is blocked**: get explicit approval for the exact plan before adding `--confirm-destructive`.
+- **Imported variables use `preserve()`**: Railway could not safely print encrypted values; `preserve()` retains the remote value.
+- **Generated code is too literal**: simplify `.railway/railway.ts`, then run another plan.
+
+## `railway.json` fallback
+
+Use this path only when the repository has no TypeScript setup. `railway.json` controls one service's build and deploy settings, not project resources such as databases, buckets, variables, or canvas groups.
+
+Start with the schema so editors validate fields:
+
+```json
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "npm run build"
+  },
+  "deploy": {
+    "preDeployCommand": ["npm run db:migrate"],
+    "startCommand": "npm start",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}
 ```
 
-Use imported helpers when needed: `service`, `postgres`, `redis`, `mysql`, `mongo`, `bucket`, `volume`, `group`, `github`, `image`, and `preserve`.
+Rules for this fallback:
 
-## Migration from config as code
+1. Include only settings the user intends to override. File values override dashboard values for that deployment.
+2. Use the canonical schema field names; do not copy internal environment patch names blindly.
+3. Keep service variables and secrets out of `railway.json`; manage them with Railway variables.
+4. Use `environments.<name>` for environment-specific overrides and `environments.pr` for PR environments.
+5. In a monorepo, place the file at the service root or set the service's custom Railway config file path to its absolute repository path.
+6. Validate the JSON after editing. A deployment is required for the config to take effect; editing the file does not mutate dashboard settings.
 
-When a service has `railway.json` or `railway.toml`:
+Example environment override:
 
-1. Run `railway config pull --force`.
-2. Translate only the intended service settings into `.railway/railway.ts`.
-3. Remove the old service-level config file or clear its custom config file path.
-4. Run `railway config plan`.
-5. Apply only when the plan matches the intended migration.
+```json
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "startCommand": "npm start"
+  },
+  "environments": {
+    "staging": {
+      "deploy": {
+        "startCommand": "npm run staging"
+      }
+    },
+    "pr": {
+      "deploy": {
+        "startCommand": "npm run preview"
+      }
+    }
+  }
+}
+```
 
-If the plan shows unexpected service deletes, variable deletes, bucket deletes, or unrelated changes, stop and inspect the generated file before applying.
-
-## Troubleshoot IaC
-
-- **Service is already managed by `railway.json` or `railway.toml`**: migrate that service first; Railway blocks dual ownership.
-- **Plan shows secrets as hidden**: this is expected. Use `--show-values` only with user approval.
-- **Apply says the plan is stale**: run `railway config plan` again, inspect the new diff, then re-apply.
-- **Destructive apply blocked**: get explicit user approval and rerun with `--confirm-destructive`.
-- **Imported variables use `preserve()`**: Railway could not safely print encrypted secret values; preserve keeps the remote value.
-- **Generated code is too literal**: edit `.railway/railway.ts` into a cleaner shape, then verify with `railway config plan`.
+For the complete field list, use the live JSON schema or Railway's Config as Code reference rather than guessing unsupported keys.
 
 ## Validated against
 
-- Docs: [infrastructure-as-code.md](https://docs.railway.com/infrastructure-as-code), [infrastructure-as-code/reference.md](https://docs.railway.com/infrastructure-as-code/reference)
-- CLI source: [config/mod.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/config/mod.rs), [config/runner.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/config/runner.rs)
+- Docs: [Infrastructure as Code](https://docs.railway.com/infrastructure-as-code), [IaC reference](https://docs.railway.com/infrastructure-as-code/reference), [Config as Code](https://docs.railway.com/guides/config-as-code), [Config as Code reference](https://docs.railway.com/reference/config-as-code)
+- CLI source: [config/mod.rs](https://github.com/railwayapp/cli/blob/v5.27.1/src/commands/config/mod.rs), [config/runner.rs](https://github.com/railwayapp/cli/blob/v5.27.1/src/commands/config/runner.rs)


### PR DESCRIPTION
Railway configuration guidance was split between the shared use-railway skill and a generated railway-config skill. Move the full IaC workflow into use-railway, prefer TypeScript IaC when the repository has TypeScript setup, fall back to railway.json otherwise, and bump the plugin version.