### PR TITLE
docs: update Cursor install instructions for the official Marketplace listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,14 @@ Add this GitHub repository as a Codex marketplace:
 
 ### Cursor
 
-There is not currently an official public Cursor listing for Railway. Add this
-GitHub repository from Cursor settings:
+Install from the official [Cursor Marketplace](https://cursor.com/marketplace/railway):
+
+```text
+/add-plugin railway
+```
+
+To install the version published by this repository directly instead, add it
+as a plugin source from Cursor settings:
 
 1. Open **Settings**.
 2. Select **Plugins**.


### PR DESCRIPTION
## Summary
- The Cursor section said "there is not currently an official public Cursor listing for Railway." That's stale, Cursor shipped a first-party marketplace (`cursor.com/marketplace`) back in February, and Railway is listed there under Infrastructure alongside Render, Vercel, Netlify, and Cloudflare, bundling the MCP, the `use-railway` skill, and a hook.
- Updated the Cursor section to lead with `/add-plugin railway` (the official marketplace install), keeping the manual "add this repo as a plugin source" steps as the alternative for installing the version published directly from this repository, mirroring the existing Claude Code section's structure (official marketplace first, this repo's own marketplace as the alternate/latest path).

## Test plan
- [x] Grepped the repo for other instances of the same stale claim, none found
- [ ] Confirm `/add-plugin railway` is the correct current slash-command syntax in Cursor (matches what's shown on the marketplace page's install button)