### PR TITLE
fix(hooks): only auto-approve a single railway command

### DIFF
--- a/plugins/railway/hooks/auto-approve-api.sh
+++ b/plugins/railway/hooks/auto-approve-api.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-# Auto-approve railway-api.sh and railway CLI commands
+# Auto-approve railway-api.sh and railway CLI commands.
+#
+# An "allow" decision covers the WHOLE Bash command, so a prefix or substring
+# match is not enough: `printf x # railway-api.sh` and `railway status; rm -rf ~`
+# both start with (or contain) a trusted token yet run something else. We only
+# approve when the command is a single simple invocation of the railway CLI or
+# the railway-api.sh helper. Anything that chains, substitutes, redirects, or
+# comments is left for the normal confirmation prompt — the safe direction.
 
 input=$(cat)
 
@@ -10,33 +17,52 @@ if [[ "$tool_name" != "Bash" ]]; then
   exit 0
 fi
 
-# Auto-approve railway-api.sh calls
-if [[ "$command" == *"railway-api.sh"* ]]; then
-  cat <<'EOF'
+approve() {
+  cat <<EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "allow",
-    "permissionDecisionReason": "Railway API call auto-approved"
+    "permissionDecisionReason": "$1"
   }
 }
 EOF
+  exit 0
+}
+
+# Command substitution and expansion fire even inside double quotes, so check the
+# raw command for them before stripping anything. Legit GraphQL uses `$var`, not
+# `$(`, backticks, or `${`.
+case "$command" in
+  *'$('* | *'`'* | *'${'*) exit 0 ;;
+esac
+
+# Build the shell skeleton: drop single- and double-quoted spans (the GraphQL
+# query and JSON args live there) so only the shell structure is left. -0777
+# slurps the whole command, so multi-line quoted args collapse away.
+skeleton=$(printf '%s' "$command" | perl -0777 -pe "s/'[^']*'//g; s/\"[^\"]*\"//g" 2>/dev/null)
+if [[ -z "$skeleton" && -n "$command" ]]; then
+  # perl unavailable or failed — can't vet the command, so don't auto-approve.
   exit 0
 fi
 
-# Auto-approve railway CLI commands, including skill telemetry env prefixes.
-railway_cli_pattern="^[[:space:]]*((RAILWAY_CALLER|RAILWAY_AGENT_SESSION|RAILWAY_SKILL_VERSION)=([^[:space:]\"']+|\"[^\"]*\"|'[^']*')[[:space:]]+)*railway([[:space:]]|$)"
-if [[ "$command" =~ $railway_cli_pattern ]]; then
-  cat <<'EOF'
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "permissionDecisionReason": "Railway CLI command auto-approved"
-  }
-}
-EOF
-  exit 0
+# On the skeleton every remaining metacharacter is top-level: command chaining
+# (`;` `|` `&`), redirection or heredoc (`<` `>`), comments (`#`), or a newline
+# joining two commands. Any of them means more than one simple command.
+case "$skeleton" in
+  *';'* | *'|'* | *'&'* | *'<'* | *'>'* | *'#'* | *$'\n'*) exit 0 ;;
+esac
+
+# Optional skill telemetry env prefixes, then the executable must BE the trusted
+# program — railway-api.sh (optionally path-qualified) or the railway CLI.
+env_prefix="^[[:space:]]*((RAILWAY_CALLER|RAILWAY_AGENT_SESSION|RAILWAY_SKILL_VERSION)=[^[:space:]]+[[:space:]]+)*"
+
+if [[ "$skeleton" =~ ${env_prefix}([^[:space:]]*/)?railway-api\.sh([[:space:]]|$) ]]; then
+  approve "Railway API call auto-approved"
+fi
+
+if [[ "$skeleton" =~ ${env_prefix}railway([[:space:]]|$) ]]; then
+  approve "Railway CLI command auto-approved"
 fi
 
 exit 0


### PR DESCRIPTION
The auto-approve hook matched `railway-api.sh` as a substring and the railway CLI as a prefix, then returned `allow` for the entire Bash command. That let unrelated commands ride along:

- `printf x # railway-api.sh` — the trusted token sits in a comment
- `railway status; rm -rf ~` — a second command after the CLI prefix
- `railway status $(...)` / backticks / pipes / redirects

Now it approves only a single simple invocation of the railway CLI or the `railway-api.sh` helper. Quoted GraphQL/JSON args are stripped before the check, so multi-line queries still auto-approve; anything that chains, substitutes, redirects, or comments falls through to the normal confirmation prompt (the safe direction).

Verified against a matrix of the bypasses above plus the documented single-line, multi-line, and env-prefixed call forms.