### PR TITLE
Document official AI integration paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Agent skills for [Railway](https://railway.com), following the [Agent Skills](https://agentskills.io) format. 
 
-This repository also includes Railway plugin packaging for Claude Code, OpenAI Codex, Grok Build, and Cursor. The plugin includes Agent Skills and local MCP configuration.
+This repository also includes Railway plugin packaging for ChatGPT, OpenAI Codex,
+Claude Code, Grok Build, and Cursor. Each plugin package includes the
+`use-railway` Agent Skill and Railway's hosted MCP server. Railway is also
+available as a connector for Claude.
 
 
 ## Railway agent setup (Installing Agent Skills and local MCP)
@@ -27,7 +30,37 @@ You can also install the Railway CLI and configure agent support in one step:
 bash <(curl -fsSL https://railway.com/install.sh) --agents -y
 ```
 
-## Installing the Railway Plugin
+## Installing Railway integrations
+
+### ChatGPT and OpenAI Codex
+
+Install the official [Railway plugin for ChatGPT and
+Codex](https://chatgpt.com/plugins/plugin_asdk_app_6a502589384081919c5decf93496c9d1)
+from the shared plugin directory. The plugin includes the `use-railway` skill
+and Railway's hosted MCP server. Connect your Railway account when prompted,
+then start a new chat or task to use the plugin.
+
+To install the version published by this repository directly, add this GitHub
+repository as a Codex marketplace:
+
+1. Open Codex.
+2. Select **Plugins** in the sidebar.
+3. Open the **More** dropdown.
+4. Click **Add more**.
+5. Enter [`railwayapp/railway-skills`](https://github.com/railwayapp/railway-skills) as the marketplace source.
+
+- Plugin manifest: [`plugins/railway/.codex-plugin/plugin.json`](plugins/railway/.codex-plugin/plugin.json)
+- Marketplace: [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json)
+
+### Claude
+
+Add the official [Railway connector for
+Claude](https://claude.ai/directory/connectors/railway) from Claude's connector
+directory. The connector uses Railway's hosted MCP server and OAuth, so it
+doesn't require a local Railway CLI installation.
+
+For terminal-based workflows with Railway's agent skill and hooks, install the
+Claude Code plugin.
 
 ### Claude Code
 
@@ -47,22 +80,6 @@ add the marketplace and install the `railway` plugin from it:
 /plugin install railway@railway-skills
 /reload-plugins
 ```
-
-### OpenAI Codex
-
-Codex support in this repository is packaged through the repo-local Codex marketplace manifest. The manifest makes the `railway` plugin available to
-Codex environments that load this repository's plugin marketplace:
-
-- Plugin manifest: [`plugins/railway/.codex-plugin/plugin.json`](plugins/railway/.codex-plugin/plugin.json)
-- Marketplace: [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json)
-
-Add this GitHub repository as a Codex marketplace:
-
-1. Open Codex.
-2. Select **Plugins** in the sidebar.
-3. Open the **More** dropdown.
-4. Click **Add more**.
-5. Enter [`railwayapp/railway-skills`](https://github.com/railwayapp/railway-skills) as the marketplace source.
 
 ### Cursor
 
@@ -86,28 +103,18 @@ as a plugin source from Cursor settings:
 
 ### Grok Build
 
-Railway is packaged for Grok as the nested plugin at `plugins/railway`.
-Marketplace entries should point at that subpath with a pinned commit:
-
-```json
-{
-  "name": "railway",
-  "source": {
-    "source": "url",
-    "url": "https://github.com/railwayapp/railway-skills.git",
-    "sha": "<full commit sha>",
-    "path": "plugins/railway"
-  }
-}
-```
-
-After the Railway entry is available in a Grok marketplace, install it from Grok's TUI:
+Railway is published in the [official xAI plugin
+marketplace](https://github.com/xai-org/plugin-marketplace). Install it from
+Grok's TUI:
 
 1. Run `grok`.
 2. Open the extensions modal with `/plugins`.
 3. Go to the **Marketplace** tab.
 4. Select `railway` from the marketplace.
 5. Press `i` to install.
+
+The official marketplace entry resolves the nested plugin at `plugins/railway`
+from this repository and pins it to a specific commit.
 
 ## Skill surface
 

--- a/README.md
+++ b/README.md
@@ -8,26 +8,26 @@ Claude Code, Grok Build, and Cursor. Each plugin package includes the
 available as a connector for Claude.
 
 
-## Railway agent setup (Installing Agent Skills and local MCP)
+## Railway agent setup
 
-To configure Railway agent support through the Railway CLI, run:
+To install Railway agent support with Railway's hosted MCP server, run:
 
 ```bash
-curl -fsSL agents.railway.com | sh
+curl -fsSL agents.railway.com | sh -s -- --remote
 ```
 
-This installs Railway skills, configures the Railway MCP server where
-supported, and checks Railway authentication for detected tools. If you are not
+This installs the Railway CLI and skills, configures `https://mcp.railway.com`
+for detected tools, and checks Railway authentication. If you are not
 authenticated, run:
 
 ```bash
 railway login
 ```
 
-You can also install the Railway CLI and configure agent support in one step:
+If the Railway CLI is already installed, configure agent support directly:
 
 ```bash
-bash <(curl -fsSL https://railway.com/install.sh) --agents -y
+railway setup agent --remote
 ```
 
 ## Installing Railway integrations
@@ -57,7 +57,7 @@ repository as a Codex marketplace:
 Add the official [Railway connector for
 Claude](https://claude.ai/directory/connectors/railway) from Claude's connector
 directory. The connector uses Railway's hosted MCP server and OAuth, so it
-doesn't require a local Railway CLI installation.
+doesn't require the Railway CLI.
 
 For terminal-based workflows with Railway's agent skill and hooks, install the
 Claude Code plugin.

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ available as a connector for Claude.
 
 ## Railway agent setup
 
-To install Railway agent support with Railway's hosted MCP server, run:
+To install the Railway CLI and configure agent support, run:
 
 ```bash
-curl -fsSL agents.railway.com | sh -s -- --remote
+curl -fsSL agents.railway.com | sh
 ```
 
-This installs the Railway CLI and skills, configures `https://mcp.railway.com`
-for detected tools, and checks Railway authentication. If you are not
-authenticated, run:
+This installs the Railway CLI and skills, configures the Railway MCP server for
+detected tools, and checks Railway authentication. If you are not authenticated,
+run:
 
 ```bash
 railway login
@@ -27,7 +27,7 @@ railway login
 If the Railway CLI is already installed, configure agent support directly:
 
 ```bash
-railway setup agent --remote
+railway setup agent
 ```
 
 ## Installing Railway integrations
@@ -64,13 +64,26 @@ Claude Code plugin.
 
 ### Claude Code
 
-Use the official Anthropic marketplace for published Claude Code releases:
+The official Anthropic marketplace is available in Claude Code by default.
+Install Railway and reload plugins:
 
 ```text
 /plugin install railway@claude-plugins-official
+/reload-plugins
 ```
 
-The official marketplace pins each plugin to a specific commit. Changes in this repository become available through `claude-plugins-official` after the Railway entry in `anthropics/claude-plugins-official` is updated to a commit that contains them.
+You can also run `/plugin` and select the **Discover** tab to browse the
+official marketplace. If Claude Code can't find Railway, refresh the marketplace
+and retry the installation:
+
+```text
+/plugin marketplace update claude-plugins-official
+```
+
+The official marketplace pins each plugin to a specific commit. Changes in this
+repository become available through `claude-plugins-official` after the Railway
+entry in `anthropics/claude-plugins-official` is updated to a commit that
+contains them.
 
 To install the version published by this repository's Claude Code marketplace,
 add the marketplace and install the `railway` plugin from it:


### PR DESCRIPTION
## Summary

Updates the README with Railway's official AI integration paths and restores the canonical agent setup command.

## Changes

- Restore `curl -fsSL agents.railway.com | sh` as the primary setup path and `railway setup agent` for existing CLI installations.
- Link the shared ChatGPT and Codex plugin listing while preserving the repository marketplace flow.
- Add the Railway connector for Claude alongside the Claude Code plugin.
- Update Claude Code guidance for its built-in official marketplace, plugin reloads, marketplace refreshes, and source installations.
- Replace the provisional Grok packaging example with installation from xAI's official plugin marketplace.

## Validation

- `git diff --check origin/main...HEAD`
- Confirmed the agent setup commands against the repository's `use-railway` skill.
- Verified the Claude Code commands against Anthropic's current plugin documentation and Railway's live `claude-plugins-official` marketplace entry.
- Verified the remaining integration paths against their repository manifests and official marketplace listings.
