### PR TITLE
fix(hooks): follow bash quoting rules when building the shell skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: Shell tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run every *.test.sh
+        run: |
+          set -euo pipefail
+          mapfile -t suites < <(find . -name '*.test.sh' -not -path './.git/*' | sort)
+          if [[ "${#suites[@]}" -eq 0 ]]; then
+            echo "No *.test.sh found — a suite was renamed or removed, so this job would pass without testing anything."
+            exit 1
+          fi
+          for suite in "${suites[@]}"; do
+            echo "::group::$suite"
+            bash "$suite"
+            echo "::endgroup::"
+          done
+
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint every *.sh
+        run: |
+          set -euo pipefail
+          mapfile -t scripts < <(find . -name '*.sh' -not -path './.git/*' | sort)
+          if [[ "${#scripts[@]}" -eq 0 ]]; then
+            echo "No *.sh found."
+            exit 1
+          fi
+          printf 'checking %s\n' "${scripts[@]}"
+          shellcheck "${scripts[@]}"
+
+  manifests:
+    name: Manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Every *.json parses
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find . -name '*.json' -not -path './.git/*' | sort)
+          for file in "${files[@]}"; do
+            jq -e . "$file" >/dev/null || { echo "invalid JSON: $file"; exit 1; }
+          done
+          echo "${#files[@]} JSON files parse"
+      - name: Each plugin declares one version across its host manifests
+        run: |
+          set -euo pipefail
+          # A plugin ships a manifest per host (.claude-plugin, .grok-plugin, …) and
+          # they all describe the same release, so their versions have to agree.
+          status=0
+          for plugin in plugins/*/; do
+            mapfile -t manifests < <(find "$plugin" -path '*/.*-plugin/plugin.json' | sort)
+            [[ "${#manifests[@]}" -eq 0 ]] && continue
+            mapfile -t versions < <(jq -r '.version' "${manifests[@]}" | sort -u)
+            if [[ "${#versions[@]}" -ne 1 ]]; then
+              echo "$plugin declares ${#versions[@]} versions: ${versions[*]}"
+              printf '  %s\n' "${manifests[@]}"
+              status=1
+            else
+              echo "$plugin ${versions[0]} (${#manifests[@]} manifests)"
+            fi
+          done
+          exit "$status"
+
+  python:
+    name: Python syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Every *.py compiles
+        run: |
+          set -euo pipefail
+          mapfile -t scripts < <(find . -name '*.py' -not -path './.git/*' | sort)
+          if [[ "${#scripts[@]}" -eq 0 ]]; then
+            echo "No *.py found."
+            exit 1
+          fi
+          python -m py_compile "${scripts[@]}"
+          echo "${#scripts[@]} Python files compile"

--- a/plugins/railway/hooks/auto-approve-api.sh
+++ b/plugins/railway/hooks/auto-approve-api.sh
@@ -37,20 +37,60 @@ case "$command" in
   *'$('* | *'`'* | *'${'*) exit 0 ;;
 esac
 
-# Build the shell skeleton: drop single- and double-quoted spans (the GraphQL
-# query and JSON args live there) so only the shell structure is left. -0777
-# slurps the whole command, so multi-line quoted args collapse away.
-skeleton=$(printf '%s' "$command" | perl -0777 -pe "s/'[^']*'//g; s/\"[^\"]*\"//g" 2>/dev/null)
-if [[ -z "$skeleton" && -n "$command" ]]; then
-  # perl unavailable or failed — can't vet the command, so don't auto-approve.
-  exit 0
-fi
+# Build the shell skeleton by dropping everything bash treats as literal data —
+# quoted spans and backslash-escaped characters — leaving only the characters
+# where bash's metacharacters actually operate. Tracking bash's quoting state
+# character by character is the whole point: `\"` is a literal to bash though it
+# looks like a delimiter, and a quote of one type inside a span of the other
+# closes nothing, so any reading that disagrees with bash on where a quoted span
+# begins and ends will hide a top-level `;` behind what it mistakes for data.
+skeleton=""
+state=unquoted
+i=0
+len=${#command}
+while ((i < len)); do
+  char=${command:i:1}
+  case "$state" in
+    unquoted)
+      case "$char" in
+        '\')
+          # Escapes whatever follows, so that character is data rather than
+          # structure — and `\<newline>` is a line continuation. A backslash with
+          # nothing after it doesn't parse; don't approve what we can't read.
+          ((i + 1 < len)) || exit 0
+          ((i++))
+          ;;
+        "'") state=single ;;
+        '"') state=double ;;
+        *) skeleton+="$char" ;;
+      esac
+      ;;
+    single)
+      # Backslash is not special inside single quotes: the span ends at the next `'`.
+      [[ "$char" == "'" ]] && state=unquoted
+      ;;
+    double)
+      case "$char" in
+        '\')
+          ((i + 1 < len)) || exit 0
+          ((i++))
+          ;;
+        '"') state=unquoted ;;
+      esac
+      ;;
+  esac
+  ((i++))
+done
+
+# An unterminated quote means the command does not parse the way we just read it.
+[[ "$state" == unquoted ]] || exit 0
 
 # On the skeleton every remaining metacharacter is top-level: command chaining
-# (`;` `|` `&`), redirection or heredoc (`<` `>`), comments (`#`), or a newline
-# joining two commands. Any of them means more than one simple command.
+# (`;` `|` `&`), redirection or heredoc (`<` `>`), comments (`#`), grouping or
+# subshells (`(` `)` `{` `}`), or a newline joining two commands. Any of them
+# means more than one simple command.
 case "$skeleton" in
-  *';'* | *'|'* | *'&'* | *'<'* | *'>'* | *'#'* | *$'\n'*) exit 0 ;;
+  *';'* | *'|'* | *'&'* | *'<'* | *'>'* | *'#'* | *'('* | *')'* | *'{'* | *'}'* | *$'\n'*) exit 0 ;;
 esac
 
 # Optional skill telemetry env prefixes, then the executable must BE the trusted

--- a/plugins/railway/hooks/auto-approve-api.sh
+++ b/plugins/railway/hooks/auto-approve-api.sh
@@ -34,7 +34,7 @@ EOF
 # raw command for them before stripping anything. Legit GraphQL uses `$var`, not
 # `$(`, backticks, or `${`.
 case "$command" in
-  *'$('* | *'`'* | *'${'*) exit 0 ;;
+  *\$\(* | *\`* | *\$\{*) exit 0 ;;
 esac
 
 # Build the shell skeleton by dropping everything bash treats as literal data —
@@ -53,7 +53,7 @@ while ((i < len)); do
   case "$state" in
     unquoted)
       case "$char" in
-        '\')
+        \\)
           # Escapes whatever follows, so that character is data rather than
           # structure — and `\<newline>` is a line continuation. A backslash with
           # nothing after it doesn't parse; don't approve what we can't read.
@@ -71,7 +71,7 @@ while ((i < len)); do
       ;;
     double)
       case "$char" in
-        '\')
+        \\)
           ((i + 1 < len)) || exit 0
           ((i++))
           ;;

--- a/plugins/railway/hooks/auto-approve-api.test.sh
+++ b/plugins/railway/hooks/auto-approve-api.test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Regression tests for auto-approve-api.sh. Run: bash auto-approve-api.test.sh
+#
+# The hook's invariant is that it never returns "allow" for a command bash would
+# run as more than one simple command. Each case below pins one reading of shell
+# quoting where a check that is not character-exact about bash's rules would let
+# a top-level `;` through as if it were quoted data.
+
+hook="$(dirname "$0")/auto-approve-api.sh"
+pass=0
+fail=0
+
+# Feeds a command to the hook and echoes "allow" or "prompt". Declining to decide
+# is silence on stdout, which is what leaves the command at the normal prompt.
+decision() {
+  local out
+  out=$(printf '%s' "$1" |
+    jq -Rs '{tool_name: "Bash", tool_input: {command: .}}' |
+    bash "$hook")
+  if [[ -z "$out" ]]; then
+    echo prompt
+  else
+    printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // "prompt"'
+  fi
+}
+
+check() {
+  local want="$1" desc="$2" cmd="$3" got
+  got=$(decision "$cmd")
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass + 1))
+    printf '  ok       %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAILED   %s (wanted %s, got %s)\n' "$desc" "$want" "$got"
+  fi
+}
+
+echo "Commands bash runs as more than one command — must prompt:"
+check prompt 'escaped double quote'          'railway \" ; touch pwned ; echo \"'
+check prompt 'escaped single quote'          "railway \\' ; touch pwned ; echo \\'"
+check prompt 'escaped quote, api.sh branch'  'railway-api.sh \" ; touch pwned ; echo \"'
+check prompt 'escaped quote, env prefix'     'RAILWAY_CALLER=x railway \" ; touch pwned ; echo \"'
+check prompt 'single quote inside double'    'railway "a'"'"'b" ; touch pwned ; echo '"'"'c"d'"'"''
+check prompt 'double quote inside single'    "railway 'a\"b' ; touch pwned ; echo \"c'd\""
+check prompt 'trailing comment'              'touch pwned # railway-api.sh'
+check prompt 'command chaining'              'railway status; touch pwned'
+check prompt 'command substitution'          'railway status $(touch pwned)'
+check prompt 'pipeline'                      'railway status | touch pwned'
+check prompt 'redirection'                   'railway status > pwned'
+check prompt 'newline between commands'      'railway status
+touch pwned'
+check prompt 'subshell'                      '(railway status; touch pwned)'
+check prompt 'brace group'                   '{ railway status; touch pwned; }'
+check prompt 'unterminated quote'            'railway " ; touch pwned'
+check prompt 'trailing lone backslash'       'railway \'
+
+echo
+echo "Documented call forms — must auto-approve:"
+check allow 'bare CLI'                       'railway status'
+check allow 'CLI with flags'                  'railway status --json'
+check allow 'quoted query and variables'      "scripts/railway-api.sh 'query { me { id } }' '{}'"
+check allow 'double quotes inside argument'   "scripts/railway-api.sh 'query { project(id: \"abc\") { id } }' '{}'"
+check allow 'telemetry env prefix'            'RAILWAY_CALLER=skill RAILWAY_SKILL_VERSION=1 railway status'
+check allow 'escaped space in argument'       'railway variables --set FOO=a\ b'
+check allow 'line continuation' "scripts/railway-api.sh \\
+  'query getEnv(\$id: String!) { environment(id: \$id) { name } }' \\
+  '{\"id\": \"env-uuid\"}'"
+check allow 'multi-line quoted query' "scripts/railway-api.sh \\
+  'query {
+    me { id }
+  }' \\
+  '{}'"
+
+echo
+echo "$pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]

--- a/plugins/railway/hooks/auto-approve-api.test.sh
+++ b/plugins/railway/hooks/auto-approve-api.test.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# The payloads below are shell source held as data, so the metacharacters and
+# backslashes in them are deliberately literal and must not be rewritten.
+# shellcheck disable=SC1003,SC2016
+#
 # Regression tests for auto-approve-api.sh. Run: bash auto-approve-api.test.sh
 #
 # The hook's invariant is that it never returns "allow" for a command bash would


### PR DESCRIPTION
## What

The auto-approve hook decides whether a Bash command is a single, simple `railway` / `railway-api.sh` invocation by removing quoted spans and checking that no top-level metacharacter is left. Building that skeleton with two independent regex substitutions reads shell quoting differently than bash does, and a command can exploit the difference to hide a top-level `;` behind what the check mistakes for quoted data — so the hook returns `allow` for a command bash runs as several commands, skipping the confirmation prompt entirely.

Two independent readings diverge:

| | skeleton the check builds | what bash actually runs |
|---|---|---|
| `railway \" ; CMD ; echo \"` | `railway \` — one command | `railway '"'`, then **`CMD`**, then `echo '"'` |
| `railway "a'b" ; CMD ; echo 'c"d'` | `railway d'` — one command | `railway a'b`, then **`CMD`**, then `echo c"d` |

The first is `\"` being a literal to bash while a delimiter scan pairs it off as a quote. The second needs no backslash at all: stripping single- and double-quoted spans in separate passes lets a quote nested inside a span of the other type open a span that was never there.

## Fix

Walk the command and track the quoting state bash itself would be in, dropping exactly what bash treats as literal data — quoted spans, and characters made literal by a preceding backslash. Decline when a quote is left open or a trailing backslash escapes nothing, since neither parses the way the check reads it. What reaches the metacharacter scan is then genuinely top-level, so that scan becomes exact rather than approximate.

Two side effects worth noting:

- Because the walk knows `\<newline>` is a line continuation and not a command separator, the documented multi-line continuation form (`AGENTS.md`, `use-railway/SKILL.md`) auto-approves again instead of falling through to a prompt.
- The perl dependency goes away, along with the branch that had to decline whenever perl was unavailable.

The heredoc form in `references/` still prompts, unchanged.

## Verification

`plugins/railway/hooks/auto-approve-api.test.sh` (new, `bash plugins/railway/hooks/auto-approve-api.test.sh`) covers both readings above, the payloads from the earlier report this check was originally written for, and the documented call forms. 24 pass on this branch; 8 fail on `main` — the six wrongful approvals, plus the two continuation forms this restores.

Separately, the check was differential-fuzzed against bash: 1500 generated quote/backslash/metacharacter commands, each one's verdict compared against whether bash really executes an injected marker as its own command. Zero wrongful approvals on this branch, three on `main`.

## Note on rollout

Installed copies keep whatever version was fetched, so merging this does not fix existing installs — anyone who installed before an update is still running their cached hook, including versions that predate the current check.
