### PR TITLE
fix(hooks): approve the bundled helper, not any file named railway-api.sh

### DIFF
--- a/plugins/railway/hooks/auto-approve-api.sh
+++ b/plugins/railway/hooks/auto-approve-api.sh
@@ -12,6 +12,7 @@ input=$(cat)
 
 tool_name=$(echo "$input" | jq -r '.tool_name // empty')
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
+cwd=$(echo "$input" | jq -r '.cwd // empty')
 
 if [[ "$tool_name" != "Bash" ]]; then
   exit 0
@@ -93,15 +94,47 @@ case "$skeleton" in
   *';'* | *'|'* | *'&'* | *'<'* | *'>'* | *'#'* | *'('* | *')'* | *'{'* | *'}'* | *$'\n'*) exit 0 ;;
 esac
 
-# Optional skill telemetry env prefixes, then the executable must BE the trusted
-# program — railway-api.sh (optionally path-qualified) or the railway CLI.
-env_prefix="^[[:space:]]*((RAILWAY_CALLER|RAILWAY_AGENT_SESSION|RAILWAY_SKILL_VERSION)=[^[:space:]]+[[:space:]]+)*"
+# Drop the optional skill telemetry env prefixes to reach the executable itself.
+env_assignment="^[[:space:]]*(RAILWAY_CALLER|RAILWAY_AGENT_SESSION|RAILWAY_SKILL_VERSION)=[^[:space:]]+[[:space:]]+(.*)$"
+remainder=$skeleton
+while [[ "$remainder" =~ $env_assignment ]]; do
+  remainder=${BASH_REMATCH[2]}
+done
+remainder=${remainder#"${remainder%%[![:space:]]*}"}
+executable=${remainder%%[[:space:]]*}
 
-if [[ "$skeleton" =~ ${env_prefix}([^[:space:]]*/)?railway-api\.sh([[:space:]]|$) ]]; then
-  approve "Railway API call auto-approved"
+# Resolve a path the way the command would, so the comparison below is about the
+# file that will run rather than the spelling used to reach it. Symlinks and `..`
+# in the directory part collapse; a directory that doesn't exist fails outright.
+canonical_path() {
+  local path=$1 dir
+  if [[ "$path" != /* ]]; then
+    [[ -n "$cwd" ]] || return 1
+    path="$cwd/$path"
+  fi
+  dir=$(cd "$(dirname "$path")" 2>/dev/null && pwd -P) || return 1
+  printf '%s/%s' "$dir" "$(basename "$path")"
+}
+
+# The helper this hook vouches for is the one shipped beside it, so locate it
+# from the hook's own path rather than trusting the name in the command. A file
+# is only that helper if it resolves to the same path; the name alone says
+# nothing about which file it is, and anything a repo or temp directory can
+# supply is not this plugin's script.
+if [[ "$executable" == *railway-api.sh ]]; then
+  hook_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P) || exit 0
+  helper=$(canonical_path "$hook_dir/../skills/use-railway/scripts/railway-api.sh") || exit 0
+  [[ -f "$helper" ]] || exit 0
+  invoked=$(canonical_path "$executable") || exit 0
+  if [[ "$invoked" == "$helper" ]]; then
+    approve "Railway API call auto-approved"
+  fi
+  exit 0
 fi
 
-if [[ "$skeleton" =~ ${env_prefix}railway([[:space:]]|$) ]]; then
+# The railway CLI is resolved from PATH by name, so require exactly that name —
+# a path-qualified `railway` is some other file and gets the normal prompt.
+if [[ "$executable" == "railway" ]]; then
   approve "Railway CLI command auto-approved"
 fi
 

--- a/plugins/railway/hooks/auto-approve-api.test.sh
+++ b/plugins/railway/hooks/auto-approve-api.test.sh
@@ -10,16 +10,29 @@
 # quoting where a check that is not character-exact about bash's rules would let
 # a top-level `;` through as if it were quoted data.
 
-hook="$(dirname "$0")/auto-approve-api.sh"
+hook_dir=$(cd "$(dirname "$0")" && pwd -P)
+hook="$hook_dir/auto-approve-api.sh"
+scripts_dir=$(cd "$hook_dir/../skills/use-railway/scripts" && pwd -P)
+skill_dir=$(dirname "$scripts_dir")
 pass=0
 fail=0
 
+# A file named like the helper but somewhere else, standing in for whatever a
+# checked-out repository or a temp directory might supply.
+decoy_dir=$(mktemp -d)
+trap 'rm -rf "$decoy_dir"' EXIT
+cp "$scripts_dir/railway-api.sh" "$decoy_dir/railway-api.sh"
+printf '#!/bin/bash\nexit 0\n' > "$decoy_dir/railway"
+chmod +x "$decoy_dir/railway"
+
 # Feeds a command to the hook and echoes "allow" or "prompt". Declining to decide
 # is silence on stdout, which is what leaves the command at the normal prompt.
+# The optional second argument is the working directory the command would run in,
+# which is what a relative path in it resolves against.
 decision() {
   local out
-  out=$(printf '%s' "$1" |
-    jq -Rs '{tool_name: "Bash", tool_input: {command: .}}' |
+  out=$(jq -nc --arg command "$1" --arg cwd "${2:-}" \
+    '{tool_name: "Bash", cwd: $cwd, tool_input: {command: $command}}' |
     bash "$hook")
   if [[ -z "$out" ]]; then
     echo prompt
@@ -30,7 +43,7 @@ decision() {
 
 check() {
   local want="$1" desc="$2" cmd="$3" got
-  got=$(decision "$cmd")
+  got=$(decision "$cmd" "${4:-}")
   if [[ "$got" == "$want" ]]; then
     pass=$((pass + 1))
     printf '  ok       %s\n' "$desc"
@@ -63,18 +76,38 @@ echo
 echo "Documented call forms — must auto-approve:"
 check allow 'bare CLI'                       'railway status'
 check allow 'CLI with flags'                  'railway status --json'
-check allow 'quoted query and variables'      "scripts/railway-api.sh 'query { me { id } }' '{}'"
-check allow 'double quotes inside argument'   "scripts/railway-api.sh 'query { project(id: \"abc\") { id } }' '{}'"
 check allow 'telemetry env prefix'            'RAILWAY_CALLER=skill RAILWAY_SKILL_VERSION=1 railway status'
 check allow 'escaped space in argument'       'railway variables --set FOO=a\ b'
+check allow 'quoted query and variables' \
+  "scripts/railway-api.sh 'query { me { id } }' '{}'" "$skill_dir"
+check allow 'double quotes inside argument' \
+  "scripts/railway-api.sh 'query { project(id: \"abc\") { id } }' '{}'" "$skill_dir"
 check allow 'line continuation' "scripts/railway-api.sh \\
   'query getEnv(\$id: String!) { environment(id: \$id) { name } }' \\
-  '{\"id\": \"env-uuid\"}'"
+  '{\"id\": \"env-uuid\"}'" "$skill_dir"
 check allow 'multi-line quoted query' "scripts/railway-api.sh \\
   'query {
     me { id }
   }' \\
-  '{}'"
+  '{}'" "$skill_dir"
+
+echo
+echo "Which railway-api.sh — only the one shipped beside this hook:"
+check allow  'helper by absolute path'        "$scripts_dir/railway-api.sh 'q'" /
+check allow  'helper by bare name from its own directory' \
+  "railway-api.sh 'q'" "$scripts_dir"
+check allow  'helper via ./ from its own directory' \
+  "./railway-api.sh 'q'" "$scripts_dir"
+check prompt 'same name in another directory' \
+  "$decoy_dir/railway-api.sh 'q'" /
+check prompt 'same name reached from a working directory that supplies it' \
+  "./railway-api.sh 'q'" "$decoy_dir"
+check prompt 'same name reached by traversing out of the plugin' \
+  "$scripts_dir/../../../../../..${decoy_dir}/railway-api.sh 'q'" /
+check prompt 'relative helper with no working directory to resolve against' \
+  "railway-api.sh 'q'"
+check prompt 'path-qualified railway is a different file than the CLI' \
+  "$decoy_dir/railway status" /
 
 echo
 echo "$pass passed, $fail failed"


### PR DESCRIPTION
## What

The trusted-program check matched the executable's *basename* with an optional path in front:

```bash
[[ "$skeleton" =~ ${env_prefix}([^[:space:]]*/)?railway-api\.sh([[:space:]]|$) ]]
```

So any file named `railway-api.sh` was auto-approved regardless of where it came from — a temp directory, or a `scripts/railway-api.sh` that arrived with a checked-out repository. All of these returned `allow` before this change:

```
./railway-api.sh                      -> allow
/tmp/evil/railway-api.sh              -> allow
../../attacker-repo/railway-api.sh    -> allow
node_modules/.bin/railway-api.sh      -> allow
```

Unlike the quoting bypass fixed in #72, this needs no shell-syntax trick: the command genuinely *is* a single simple invocation, which is exactly what the check is looking for. The gap is that a filename says nothing about which file will run.

This was raised in the July report that prompted #68 (remediation item 5 — "resolve and compare the API helper's canonical absolute path rather than accepting its filename anywhere in the string") and wasn't implemented then.

## Fix

Resolve the invoked path and compare it against the helper shipped beside the hook, located from the hook's own path rather than from the name in the command. Relative paths resolve against the `cwd` the hook is given, so the documented `scripts/railway-api.sh` form still auto-approves when it really does reach this plugin's copy, while the same spelling pointing anywhere else falls through to the prompt.

Two narrower consequences, both landing on the prompt rather than an approval:

- A relative path with no `cwd` to resolve against can't be vouched for.
- `railway` must now be exactly that name. A path-qualified `./railway` is a different file than the CLI resolved from PATH, so it no longer matches.

Worth a reviewer's opinion: this trades some auto-approval away. Anyone running the helper out of a repo checkout rather than an installed plugin now gets a prompt, because that copy isn't the one this hook ships with. That seemed right — the hook shouldn't vouch for a script it can't identify — but it is a deliberate behaviour change, not just a hole being closed.

## Verification

`auto-approve-api.test.sh` grows a section covering which `railway-api.sh` is being run: the helper by absolute path, by bare name from its own directory, and via `./`, all approved; a same-named copy elsewhere, one reached from a working directory that supplies it, one reached by traversing out of the plugin, a relative path with no `cwd`, and a path-qualified `railway`, all prompted. 32 pass on this branch; 4 of the new cases fail against `main`.

The structural checks from #72 are untouched and re-verified, since this rewrites how the executable is extracted: the differential fuzz against bash still reports 0 wrongful approvals across 1000 generated quote/backslash/metacharacter commands, and shellcheck is clean.
