### PR TITLE
fix(railway): quote plugin root in hook command

### DIFF
--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using Railway skills and the hosted MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/hooks/hooks.json
+++ b/plugins/railway/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh"
+            "command": "bash \"${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh\""
           }
         ]
       }

--- a/plugins/railway/hooks/hooks.test.sh
+++ b/plugins/railway/hooks/hooks.test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# shellcheck disable=SC1003,SC2016
+#
+# Regression tests for hooks.json command execution with spaces in plugin root path.
+# Run: bash hooks.test.sh
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd -P)
+plugin_dir=$(cd "$script_dir/.." && pwd -P)
+
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+space_plugin_dir="$temp_dir/Railway Plugin"
+cp -R "$plugin_dir" "$space_plugin_dir"
+
+hooks_json="$space_plugin_dir/hooks/hooks.json"
+command_template=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$hooks_json")
+
+payload=$(jq -nc '{tool_name: "Bash", cwd: "", tool_input: {command: "railway status"}}')
+
+pass=0
+fail=0
+
+check_scenario() {
+  local desc="$1" env_grok="$2" env_claude="$3"
+  local env_opts=()
+  if [[ -n "$env_grok" ]]; then
+    env_opts+=(GROK_PLUGIN_ROOT="$env_grok")
+  else
+    env_opts+=(GROK_PLUGIN_ROOT=)
+  fi
+  if [[ -n "$env_claude" ]]; then
+    env_opts+=(CLAUDE_PLUGIN_ROOT="$env_claude")
+  else
+    env_opts+=(CLAUDE_PLUGIN_ROOT=)
+  fi
+
+  local out
+  out=$(printf '%s' "$payload" | env "${env_opts[@]}" bash -c "$command_template" 2>/dev/null || true)
+  local decision
+  decision=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null || true)
+
+  if [[ "$decision" == "allow" ]]; then
+    pass=$((pass + 1))
+    printf '  ok       %s\n' "$desc"
+  else
+    fail=$((fail + 1))
+    printf '  FAILED   %s (wanted "allow", got "%s")\n' "$desc" "$decision"
+  fi
+}
+
+echo "Testing hooks.json command execution with spaces in path:"
+check_scenario "CLAUDE_PLUGIN_ROOT with space (GROK_PLUGIN_ROOT unset)" "" "$space_plugin_dir"
+check_scenario "GROK_PLUGIN_ROOT with space (precedence over CLAUDE_PLUGIN_ROOT)" "$space_plugin_dir" "/other/path"
+
+echo
+echo "$pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -99,7 +99,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.7" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.8" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -123,7 +123,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.7` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.8` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.


### PR DESCRIPTION
## Summary

- run the Railway `PreToolUse` hook through an explicit `bash` interpreter;
- quote the resolved plugin root so paths containing spaces are not word-split;
- add regression coverage for both the Claude and Grok plugin-root paths;
- bump the published plugin version and telemetry stamp from `1.3.7` to `1.3.8`.

Fixes #44.
Fixes #56.

## Root cause

The hook command executed the `.sh` file as an unquoted path:

```json
"${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh"
```

When the plugin root contains a space, the command is word-split before the
script path is executed. A bare `.sh` path also does not reliably select Bash on
Windows integrations.

The command now explicitly invokes Bash and quotes the complete resolved path:

```json
"bash \"${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh\""
```

## Regression coverage

The new `plugins/railway/hooks/hooks.test.sh`:

- reads the actual command out of `hooks.json` rather than restating it;
- copies the plugin into a temporary directory whose name contains a space;
- verifies the `CLAUDE_PLUGIN_ROOT` fallback;
- verifies that `GROK_PLUGIN_ROOT` takes precedence over `CLAUDE_PLUGIN_ROOT`;
- asserts the hook returns `permissionDecision: allow`.

### Mutation proof

The same test file was run against the unpatched command, using a detached
worktree at the base commit with only the test file copied in:

```
Testing hooks.json command execution with spaces in path:
  FAILED   CLAUDE_PLUGIN_ROOT with space (GROK_PLUGIN_ROOT unset) (wanted "allow", got "")
  FAILED   GROK_PLUGIN_ROOT with space (precedence over CLAUDE_PLUGIN_ROOT) (wanted "allow", got "")

0 passed, 2 failed
BASE_TEST_EXIT=1
```

With this change applied:

```
Testing hooks.json command execution with spaces in path:
  ok       CLAUDE_PLUGIN_ROOT with space (GROK_PLUGIN_ROOT unset)
  ok       GROK_PLUGIN_ROOT with space (precedence over CLAUDE_PLUGIN_ROOT)

2 passed, 0 failed
FIXED_TEST_EXIT=0
```

So the test fails in both scenarios without the fix and passes with it.

## Validation

Every item below was executed on this branch; the quoted numbers are the
observed output.

- `plugins/railway/hooks/hooks.test.sh` — 2 passed, 0 failed
- mutation proof against the unpatched command — 0 passed, 2 failed (exit 1)
- `plugins/railway/hooks/auto-approve-api.test.sh` — 32 passed, 0 failed
- both repository `*.test.sh` suites pass
- ShellCheck 0.9.0 over every tracked `*.sh` — no findings
- all 11 tracked JSON files parse with `jq`
- all four host manifests report `1.3.8`, with a single unique version across them
- `SKILL.md` carries 2 `skill:use-railway@1.3.8` stamps and no remaining `1.3.7`
- `git diff --check` — clean
- diff: 7 files changed, 67 insertions(+), 7 deletions(-)

Environment: Ubuntu 22.04 x86_64, git 2.53.0, bash 5.1, jq 1.7, Python 3.12.1.

The patch was reproduced from scratch on top of
`5d1e97178f86c82795d6737928bd641e0552166a` and fully revalidated before opening
this pull request.
