### PR TITLE
fix(hooks): decide by the word bash runs, and decline the subcommands that run a command

### DIFF
--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using Railway skills and the hosted MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/hooks/auto-approve-api.sh
+++ b/plugins/railway/hooks/auto-approve-api.sh
@@ -7,6 +7,10 @@
 # approve when the command is a single simple invocation of the railway CLI or
 # the railway-api.sh helper. Anything that chains, substitutes, redirects, or
 # comments is left for the normal confirmation prompt — the safe direction.
+#
+# The CLI itself is the other half of that judgement: a few subcommands exist to
+# run a command somewhere, so approving them approves whatever they are handed.
+# Those are declined below, by the word bash would actually pass.
 
 input=$(cat)
 
@@ -38,17 +42,40 @@ case "$command" in
   *\$\(* | *\`* | *\$\{*) exit 0 ;;
 esac
 
-# Build the shell skeleton by dropping everything bash treats as literal data —
-# quoted spans and backslash-escaped characters — leaving only the characters
-# where bash's metacharacters actually operate. Tracking bash's quoting state
-# character by character is the whole point: `\"` is a literal to bash though it
-# looks like a delimiter, and a quote of one type inside a span of the other
-# closes nothing, so any reading that disagrees with bash on where a quoted span
-# begins and ends will hide a top-level `;` behind what it mistakes for data.
+# Read the command once, the way bash reads it, and keep the two answers that
+# matter separately:
+#
+#   skeleton — only the characters bash could act on as syntax. Quoted spans and
+#              backslash-escaped characters are data, so they leave nothing here
+#              and the metacharacter scan below is exact rather than approximate.
+#   words    — the words bash would actually pass, with quotes removed and
+#              escapes resolved, split on unquoted whitespace. The executable and
+#              the subcommand are decided from these, because the skeleton is not
+#              the word: bash runs `rxailway` for `r'x'ailway` while the skeleton
+#              reads `railway`.
+#
+# quoted[] records which words carried any quoting or escaping at all. A word
+# that did is not something this hook can vouch for by name, so the executable
+# and the telemetry prefixes are required to be written plainly.
 skeleton=""
+words=()
+quoted=()
+word=""
+in_word=0
+word_quoted=0
 state=unquoted
 i=0
 len=${#command}
+
+end_word() {
+  ((in_word)) || return 0
+  words+=("$word")
+  quoted+=("$word_quoted")
+  word=""
+  in_word=0
+  word_quoted=0
+}
+
 while ((i < len)); do
   char=${command:i:1}
   case "$state" in
@@ -56,52 +83,109 @@ while ((i < len)); do
       case "$char" in
         \\)
           # Escapes whatever follows, so that character is data rather than
-          # structure — and `\<newline>` is a line continuation. A backslash with
-          # nothing after it doesn't parse; don't approve what we can't read.
+          # structure — and `\<newline>` is a line continuation, which joins the
+          # line and contributes nothing. A backslash with nothing after it
+          # doesn't parse; don't approve what we can't read.
           ((i + 1 < len)) || exit 0
           ((i++))
+          next=${command:i:1}
+          if [[ "$next" != $'\n' ]]; then
+            word+="$next"
+            in_word=1
+            word_quoted=1
+          fi
           ;;
-        "'") state=single ;;
-        '"') state=double ;;
-        *) skeleton+="$char" ;;
+        "'")
+          state=single
+          in_word=1
+          word_quoted=1
+          ;;
+        '"')
+          state=double
+          in_word=1
+          word_quoted=1
+          ;;
+        ' ' | $'\t')
+          skeleton+="$char"
+          end_word
+          ;;
+        *)
+          skeleton+="$char"
+          word+="$char"
+          in_word=1
+          ;;
       esac
       ;;
     single)
       # Backslash is not special inside single quotes: the span ends at the next `'`.
-      [[ "$char" == "'" ]] && state=unquoted
+      if [[ "$char" == "'" ]]; then
+        state=unquoted
+      else
+        word+="$char"
+      fi
       ;;
     double)
       case "$char" in
         \\)
           ((i + 1 < len)) || exit 0
           ((i++))
+          next=${command:i:1}
+          # Inside double quotes a backslash is literal unless it escapes one of
+          # the characters that would otherwise be special there.
+          case "$next" in
+            '$' | '`' | '"' | $'\\' | $'\n') ;;
+            *) word+="\\" ;;
+          esac
+          [[ "$next" == $'\n' ]] || word+="$next"
           ;;
         '"') state=unquoted ;;
+        *) word+="$char" ;;
       esac
       ;;
   esac
   ((i++))
 done
+end_word
 
 # An unterminated quote means the command does not parse the way we just read it.
 [[ "$state" == unquoted ]] || exit 0
 
 # On the skeleton every remaining metacharacter is top-level: command chaining
 # (`;` `|` `&`), redirection or heredoc (`<` `>`), comments (`#`), grouping or
-# subshells (`(` `)` `{` `}`), or a newline joining two commands. Any of them
-# means more than one simple command.
+# subshells (`(` `)` `{` `}`), or a newline joining two commands. An unquoted
+# expansion (`$`, `~`, or a glob) is here too: it means the word bash runs is
+# not the word we just read, and the file it names may not exist yet.
 case "$skeleton" in
   *';'* | *'|'* | *'&'* | *'<'* | *'>'* | *'#'* | *'('* | *')'* | *'{'* | *'}'* | *$'\n'*) exit 0 ;;
+  *'$'* | *'~'* | *'*'* | *'?'* | *'['*) exit 0 ;;
 esac
 
 # Drop the optional skill telemetry env prefixes to reach the executable itself.
-env_assignment="^[[:space:]]*(RAILWAY_CALLER|RAILWAY_AGENT_SESSION|RAILWAY_SKILL_VERSION)=[^[:space:]]+[[:space:]]+(.*)$"
-remainder=$skeleton
-while [[ "$remainder" =~ $env_assignment ]]; do
-  remainder=${BASH_REMATCH[2]}
+while ((${#words[@]})); do
+  [[ "${quoted[0]}" == 0 ]] || exit 0
+  case "${words[0]}" in
+    RAILWAY_CALLER=* | RAILWAY_AGENT_SESSION=* | RAILWAY_SKILL_VERSION=*)
+      words=("${words[@]:1}")
+      quoted=("${quoted[@]:1}")
+      ;;
+    *) break ;;
+  esac
 done
-remainder=${remainder#"${remainder%%[![:space:]]*}"}
-executable=${remainder%%[[:space:]]*}
+
+((${#words[@]})) || exit 0
+executable=${words[0]}
+[[ "${quoted[0]}" == 0 ]] || exit 0
+
+# `railway run`, `railway ssh`, `railway connect` and `railway sandbox exec` all
+# exist to run a command — locally or on a service — so approving the CLI by name
+# would approve whatever they are given. The name of the CLI says nothing about
+# what the invocation does, so decline these wherever they appear in the words
+# rather than guessing which position holds the subcommand.
+for arg in "${words[@]:1}"; do
+  case "$arg" in
+    run | ssh | shell | connect | exec) exit 0 ;;
+  esac
+done
 
 # Resolve a path the way the command would, so the comparison below is about the
 # file that will run rather than the spelling used to reach it. Symlinks and `..`
@@ -122,6 +206,9 @@ canonical_path() {
 # nothing about which file it is, and anything a repo or temp directory can
 # supply is not this plugin's script.
 if [[ "$executable" == *railway-api.sh ]]; then
+  # A name with no slash is looked up in PATH, not in the working directory, so
+  # the file we would resolve is not the one bash would run.
+  [[ "$executable" == */* ]] || exit 0
   hook_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P) || exit 0
   helper=$(canonical_path "$hook_dir/../skills/use-railway/scripts/railway-api.sh") || exit 0
   [[ -f "$helper" ]] || exit 0

--- a/plugins/railway/hooks/auto-approve-api.test.sh
+++ b/plugins/railway/hooks/auto-approve-api.test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # The payloads below are shell source held as data, so the metacharacters and
 # backslashes in them are deliberately literal and must not be rewritten.
-# shellcheck disable=SC1003,SC2016
+# shellcheck disable=SC1003,SC2016,SC2088
 #
 # Regression tests for auto-approve-api.sh. Run: bash auto-approve-api.test.sh
 #
@@ -71,11 +71,39 @@ check prompt 'subshell'                      '(railway status; touch pwned)'
 check prompt 'brace group'                   '{ railway status; touch pwned; }'
 check prompt 'unterminated quote'            'railway " ; touch pwned'
 check prompt 'trailing lone backslash'       'railway \'
+check prompt 'ANSI-C quoting is not a quoted span' \
+  "railway \$'\\'' ; touch pwned ; : '\\'"
+check prompt 'localised string is not a quoted span' \
+  'railway $" ; touch pwned ; echo "'
+
+echo
+echo "The word bash runs is not the skeleton — must prompt:"
+check prompt 'quoted span inside the command name'  "r'x'ailway status"
+check prompt 'empty quoted span inside the name'    "rail''way status"
+check prompt 'quoting reaches a path through the name' \
+  "'$decoy_dir/'railway status" /
+check prompt 'escape inside the command name'       'rail\way status'
+check prompt 'quoted telemetry prefix name'         "RAILWAY'_'CALLER=x railway status"
+check prompt 'glob in the command name'             'railwa? status'
+check prompt 'variable in the command name'         'railwa$y status'
+check prompt 'tilde reaches a home-relative path'   '~/railway status'
+
+echo
+echo "CLI subcommands that run a command are not covered by the CLI's name:"
+check prompt 'run executes a local command'         'railway run -- sh -c id'
+check prompt 'run with flags before the command'    'railway run --service api -- sh -c id'
+check prompt 'quoted subcommand is still the subcommand' "railway 'run' -- sh -c id"
+check prompt 'ssh executes on a service'            'railway ssh --service api sh -c id'
+check prompt 'sandbox exec executes in a sandbox'   'railway sandbox exec my-box -- sh -c id'
+check prompt 'connect opens a local database shell' 'railway connect Postgres'
 
 echo
 echo "Documented call forms — must auto-approve:"
 check allow 'bare CLI'                       'railway status'
 check allow 'CLI with flags'                  'railway status --json'
+check allow 'logs by service'                 'railway logs --service api --environment production'
+check allow 'deploy'                          'railway up --detach'
+check allow 'quoted argument value'           "railway variables --set 'FOO=a b'"
 check allow 'telemetry env prefix'            'RAILWAY_CALLER=skill RAILWAY_SKILL_VERSION=1 railway status'
 check allow 'escaped space in argument'       'railway variables --set FOO=a\ b'
 check allow 'quoted query and variables' \
@@ -94,7 +122,7 @@ check allow 'multi-line quoted query' "scripts/railway-api.sh \\
 echo
 echo "Which railway-api.sh — only the one shipped beside this hook:"
 check allow  'helper by absolute path'        "$scripts_dir/railway-api.sh 'q'" /
-check allow  'helper by bare name from its own directory' \
+check prompt 'helper by bare name resolves in PATH, not the working directory' \
   "railway-api.sh 'q'" "$scripts_dir"
 check allow  'helper via ./ from its own directory' \
   "./railway-api.sh 'q'" "$scripts_dir"

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -99,7 +99,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.7" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.3.8" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -123,7 +123,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.7` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.8` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.


### PR DESCRIPTION
Closes the remaining ways a Bash command can read as a plain `railway` call to the hook and as something else to bash.

- reads the executable from the words bash would pass, not from the skeleton, so `r'x'ailway status` and `'./'railway status` stop resolving to the CLI
- requires the executable and the telemetry prefixes to be unquoted, since quoting hides which file the name reaches
- treats top-level `$`, `~` and globs as metacharacters, which also covers `$'...'` quoting
- declines `run`, `ssh`, `connect`, `shell` and `exec` by the word bash passes, because those subcommands run a command and the CLI's name says nothing about that
- a bare `railway-api.sh` now prompts: it resolves in PATH, not in the working directory, so the file checked was never the file that would run
- bumps to 1.3.8

51 hook cases, all green, and the forms the skill documents still auto-approve.
