### PR TITLE
Quote plugin root in hook command so paths with spaces work

### DIFF
--- a/plugins/railway/hooks/hooks.json
+++ b/plugins/railway/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh"
+            "command": "\"${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Problem

`plugins/railway/hooks/hooks.json` interpolates the plugin root unquoted:

```json
"command": "${GROK_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/auto-approve-api.sh"
```

When the plugin root contains a space, the shell word-splits the path and tries to execute only the first segment:

```
bash: C:/Users/First: No such file or directory   (exit 127)
```

This is the common case on Windows, where the home directory is `C:\Users\First Last`. Since this is a `PreToolUse` hook matching `Bash`, it fires on **every** Bash tool call, so the error repeats for the entire session.

The failure is non-blocking, so nothing breaks — but the hook never runs, meaning Railway CLI/API calls silently stop being auto-approved, which is the hook's entire purpose. It also adds noise to every session.

## Fix

Wrap the interpolation in escaped double quotes so the shell treats the path as a single argument. One line, no behaviour change where the path has no space.

## Verification

With `CLAUDE_PLUGIN_ROOT="C:/Users/Alex Borbely/.claude/plugins/cache/railway-skills/railway/1.0.0"`:

```
-- unquoted (current)
bash: C:/Users/Alex: No such file or directory
   exit=127

-- quoted (this PR)
   exit=0
```

Confirmed the hook still returns its auto-approve payload correctly after the change:

```json
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "allow",
    "permissionDecisionReason": "Railway CLI command auto-approved"
  }
}
```

JSON validity re-checked after the edit.

## Context

Found this while tracing ~3,100 occurrences of the error across local Claude Code session transcripts spanning three months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)