### PR TITLE
Update Railway skill for CLI v5.49.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Use GraphQL for operations without a dedicated command or MCP tool. Prefer the C
 
 - Endpoint: `https://backboard.railway.com/graphql/v2`
 - CLI (5.28+): `railway api`, with `search`, `describe`, and `schema` for discovery.
-- Legacy helper: `plugins/railway/skills/use-railway/scripts/railway-api.sh`, retained for older CLI compatibility. It attaches `X-Railway-Skill-Id`, `X-Railway-Skill-Version`, and `X-Railway-Agent-Session` headers.
+- Legacy helper: `plugins/railway/skills/use-railway/scripts/railway-api.sh`, retained for older CLI compatibility and still required by the database analysis scripts (`dal.py`, `analyze-postgres.py`). It attaches `X-Railway-Skill-Id`, `X-Railway-Skill-Version`, and `X-Railway-Agent-Session` headers.
 
 ### API authentication
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,11 @@ References:
 | Create or connect resources | `references/setup.md` | Projects, services, databases, buckets, templates, workspaces |
 | Ship code or manage releases | `references/deploy.md` | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | `references/configure.md` | Environments, variables, config patches, domains, networking |
-| Manage feature flags | `references/feature-flags.md` | MCP list/get/set/delete; dashboard for rules; SDK runtime reads |
-| Define configuration in source control | `references/iac.md` | TypeScript IaC selection, `.railway/railway.ts`, `railway.json` fallback, config init/pull/plan/apply, drift checks |
+| Manage feature flags | `references/feature-flags.md` | MCP registry operations; CLI targeting rules and rollouts; SDK runtime reads |
+| Define configuration in source control | `references/iac.md` | TypeScript/Python/Go IaC, legacy migration, imports, saved plans, apply and drift checks |
+| Manage database features | `references/databases.md` | Postgres PITR, backups, HA and PgBouncer; MySQL/Redis HA |
+| Inspect costs or manage limits | `references/usage.md` | Workspace/project/service usage and workspace/agent spending limits |
+| Run coding agents on Railway | `references/cloud-agents.md` | Cloud agent lifecycle, harness launches, desktop SSH setup |
 | Check health or debug failures | `references/operate.md` | Status, logs, metrics, build/runtime triage, recovery |
 | Use a sandbox or build remotely | `references/sandbox.md` | Sandboxes: create/fork, remote exec, remote template builds, checkpoints, port forwarding (requires Priority Boarding) |
 | Analyze databases | `references/analyze-db.md` | Database introspection and performance analysis, then DB-specific refs |
@@ -49,9 +52,9 @@ Choose the Railway operation path that matches the job.
 
 - Railway CLI (`railway`): local-machine workflows such as current-directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, and exact command output.
 - Remote MCP (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment status, feature flags, bounded logs, simple redeploys, simple project creation, and complex workflows through `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
-- GraphQL: operations that neither MCP nor CLI exposes.
+- GraphQL through `railway api`: operations without a dedicated MCP tool or CLI command, with live schema search and inspection.
 
-Optional: if the current agent already has a user-installed local CLI MCP (`railway mcp`) configured, it can be used for CLI-backed platform operations not yet exposed by remote MCP. Published plugin configs do not install or launch local CLI MCP.
+Optional: an already configured in-process CLI MCP (`railway mcp local`) can supply operations not available through hosted MCP. Bare `railway mcp` starts the hosted proxy using CLI login; it is not the in-process server. Published plugin configs use direct hosted HTTP with editor OAuth.
 
 ### Railway CLI
 
@@ -68,27 +71,26 @@ Published plugin MCP configs use Railway's hosted MCP server for single-click se
 - Keep `plugins/railway/.mcp.json`, `plugins/railway/.cursor-plugin/mcp.json`, and `plugins/railway/.grok-plugin/mcp.json` in sync.
 - Plugin MCP configs must point at `https://mcp.railway.com` with HTTP transport.
 - Do not store credentials in plugin MCP config. Remote MCP authentication uses Railway OAuth.
-- Railway CLI still exposes `railway mcp` for users who explicitly install a local CLI-backed MCP server, but published plugin configs should not launch it.
+- CLI installation defaults to the hosted proxy (`railway mcp`, with `mcp proxy` retained as an alias). `railway mcp install --oauth` selects direct HTTP/editor OAuth; `--local` selects `railway mcp local`. `--remote` is an alias for the proxy default. Published plugin configs keep direct HTTP transport.
 
 ### GraphQL API
 
-Use GraphQL for operations the CLI doesn't expose.
+Use GraphQL for operations without a dedicated command or MCP tool. Prefer the CLI's authenticated API client.
 
 - Endpoint: `https://backboard.railway.com/graphql/v2`
-- API helper: `plugins/railway/skills/use-railway/scripts/railway-api.sh`
-- The API helper attaches `X-Railway-Skill-Id`, `X-Railway-Skill-Version`, and `X-Railway-Agent-Session` headers.
+- CLI (5.28+): `railway api`, with `search`, `describe`, and `schema` for discovery.
+- Legacy helper: `plugins/railway/skills/use-railway/scripts/railway-api.sh`, retained for older CLI compatibility. It attaches `X-Railway-Skill-Id`, `X-Railway-Skill-Version`, and `X-Railway-Agent-Session` headers.
 
-### API token
+### API authentication
 
-Token location: `~/.railway/config.json` under `user.token`.
+`railway api` uses normal CLI authentication and token refresh. The legacy helper reads only `~/.railway/config.json` under `user.token`; it does not implement environment-token selection or OAuth refresh.
 
 Example:
 
 ```bash
-# From plugins/railway/skills/use-railway
-scripts/railway-api.sh \
+railway api \
   'query getEnv($id: String!) { environment(id: $id) { name } }' \
-  '{"id": "env-uuid"}'
+  --variables '{"id": "env-uuid"}'
 ```
 
 API docs: https://docs.railway.com/api/llms-docs.md

--- a/plugins/railway/.claude-plugin/plugin.json
+++ b/plugins/railway/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Claude Code. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.codex-plugin/plugin.json
+++ b/plugins/railway/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "description": "Deploy, configure, monitor, and troubleshoot apps and infrastructure on Railway from Codex using Railway skills and the hosted MCP server.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/.cursor-plugin/plugin.json
+++ b/plugins/railway/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "railway",
   "displayName": "Railway",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Cursor. Manage services, environments, deployments, databases, object storage, networking, and observability.",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "author": {
     "name": "Railway",
     "email": "contact@railway.com"

--- a/plugins/railway/.grok-plugin/plugin.json
+++ b/plugins/railway/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "railway",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "description": "Railway agent skills and hosted MCP server for deploying, configuring, monitoring, and troubleshooting apps and infrastructure on Railway from Grok. Manage services, environments, deployments, databases, object storage, networking, and observability.",
   "author": {
     "name": "Railway",

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -2,8 +2,8 @@
 name: use-railway
 description: >
   Operate Railway infrastructure: sign up for or sign in to a Railway account,
-  create projects, provision services and databases, manage object storage
-  buckets, deploy code, configure infrastructure as code, environments and variables, manage domains,
+  create projects, provision services, databases, and buckets, deploy code,
+  configure infrastructure as code, environments and variables, manage domains,
   troubleshoot failures, check status and metrics, manage feature flags,
   database recovery and HA, cloud agents, usage limits, and Railway agent tooling.
   Use this skill whenever

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -5,7 +5,8 @@ description: >
   create projects, provision services and databases, manage object storage
   buckets, deploy code, configure infrastructure as code, environments and variables, manage domains,
   troubleshoot failures, check status and metrics, manage feature flags,
-  set up Railway agent tooling, and query Railway docs. Use this skill whenever
+  database recovery and HA, cloud agents, usage limits, and Railway agent tooling.
+  Use this skill whenever
   the user mentions Railway, feature flags, flag rollout, targeting rules,
   signing up, creating an account, registering, logging in, deployments,
   services, environments, buckets, object storage, build failures, agent setup,
@@ -38,13 +39,13 @@ Railway has three agent-facing operation paths. Choose the path that matches the
 
 - **Railway CLI** (`railway`): workflows that depend on local machine state such as current working directory deploys, `railway up`, `railway run`, SSH, database analysis scripts, local linking, interactive setup, or exact command output.
 - **Remote MCP** (`https://mcp.railway.com`): default plugin MCP path for account/project/service discovery, deployment state, bounded logs, feature flags, simple redeploys, simple project creation, or complex Railway workflows that can be handed to `railway-agent`. Remote MCP uses Railway OAuth and does not depend on local CLI state.
-- **GraphQL**: operations that neither MCP nor CLI exposes, or when a reference gives a specific GraphQL fallback.
+- **GraphQL through `railway api`**: operations without a dedicated MCP tool or CLI command. Use schema search and inspection before constructing unfamiliar queries.
 
 If multiple paths are available, choose the one that preserves the needed context. The CLI fits workflows that need the current repo, local credentials, SSH, database scripts, or exact command output. Remote MCP fits OAuth-scoped platform operations that do not need local files or CLI state.
 
-Optional: if the current agent already has a user-installed local CLI MCP (`railway mcp`) configured, it can be used for CLI-backed platform operations not yet exposed by remote MCP. Published plugin configs do not install or launch local CLI MCP.
+Optional: an already configured in-process CLI MCP (`railway mcp local`) can supply operations not available through hosted MCP. A bare `railway mcp` now starts the hosted MCP proxy using CLI authentication; it is not the in-process server. Published plugin configs connect directly to hosted MCP with editor OAuth.
 
-Use `scripts/railway-api.sh` for GraphQL only when neither MCP nor CLI exposes the operation, or when a reference gives a specific GraphQL fallback.
+Prefer `railway api` (CLI 5.28+) for GraphQL execution. The legacy `scripts/railway-api.sh` remains a compatibility fallback for older CLIs; see [request.md](references/request.md).
 
 ## Parsing Railway URLs
 
@@ -58,13 +59,13 @@ https://railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>
 The URL always contains `projectId` and `serviceId`. It may contain `environmentId` as a query parameter. If the environment ID is missing and the user specifies an environment by name (e.g., "production"), resolve it:
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'query getProject($id: String!) {
     project(id: $id) {
       environments { edges { node { id name } } }
     }
   }' \
-  '{"id": "<PROJECT_ID>"}'
+  --variables '{"id": "<PROJECT_ID>"}'
 ```
 
 Match the environment name (case-insensitive) to get the `environmentId`.
@@ -99,7 +100,7 @@ Before any mutation, verify the tool path and context:
 
 ```bash
 command -v railway                # CLI installed
-RAILWAY_CALLER="skill:use-railway@1.3.7" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
+RAILWAY_CALLER="skill:use-railway@1.4.0" RAILWAY_AGENT_SESSION="railway-skill-$(date +%s)-$$" railway whoami --json
 railway --version                 # check CLI version
 ```
 
@@ -123,7 +124,7 @@ Check once per session and don't re-run it after acting; the restart prompt to t
 
 When Railway MCP is available and the job is a platform-state read, use the matching MCP read instead of shelling out. If using the CLI path, run the CLI checks above.
 
-For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.3.7` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
+For Railway CLI calls made while this skill is active, prefix the command with `RAILWAY_CALLER=skill:use-railway@1.4.0` and a stable `RAILWAY_AGENT_SESSION` reused for the current user request. Generate the session id once per user request, then reuse that exact value for later Railway CLI calls in the same workflow. Do not run a separate `export` preflight solely for telemetry; inline env prefixes keep the shell output concise and avoid leaking setup steps into every response.
 
 **Context resolution - URL IDs always win:**
 - If the user provides a Railway URL, extract IDs from it. Do NOT run `railway status --json`; it returns the locally linked project, which is usually unrelated.
@@ -205,6 +206,8 @@ The browser transport needs none of this — the CLI opens the browser on the us
 
 When you see `code: NOT_AUTHENTICATED`, authenticate the user with `railway login`, then retry the original command.
 
+`OAUTH_INSUFFICIENT_GRANT` is different: the session is valid but lacks access to the resource. Check IDs, workspace membership, and the integration's grant scope instead of looping through login; see [operate.md](references/operate.md).
+
 **Fully unattended (no human at all)**: set `RAILWAY_API_TOKEN` (account-scoped) or `RAILWAY_TOKEN` (project-scoped) instead of running an interactive login. A brand-new user with no token and no human present cannot complete signup — there is no headless account-creation path.
 
 ## Agent tooling
@@ -216,7 +219,7 @@ Set up Railway skills, MCP, and authentication with:
 ```bash
 railway setup agent
 railway setup agent -y
-railway setup agent --remote
+railway setup agent --oauth
 ```
 
 `railway setup agent -y` skips the interactive login flow. If the user isn't authenticated after setup, run `railway login`.
@@ -224,15 +227,23 @@ railway setup agent --remote
 Install or update MCP and skills directly when the user names a target tool:
 
 ```bash
-railway mcp install --remote
-railway mcp install --agent codex --remote
-railway mcp install --agent cursor --remote
+railway mcp install                              # hosted MCP via CLI login
+railway mcp install --agent codex --oauth         # direct HTTP, editor OAuth
+railway mcp install --agent cursor --oauth
 railway skills
 railway skills update --agent codex
 railway skills remove --agent cursor
 ```
 
-Supported targets include `claude-code`, `cursor`, `codex`, `opencode`, `copilot`, and `factory-droid`. The `--remote` flag configures `https://mcp.railway.com` instead of a local `railway mcp` stdio server.
+Supported targets include `claude-code`, `cursor`, `codex`, `opencode`, `copilot`, and `factory-droid`.
+
+| Install mode | Transport and authentication |
+|---|---|
+| Default / `--remote` | `railway mcp` stdio proxy to hosted MCP, authenticated by `railway login` |
+| `--oauth` | Direct HTTP to `https://mcp.railway.com`, authenticated by editor OAuth; matches the published plugins |
+| `--local` | In-process GraphQL-backed stdio server, invoked as `railway mcp local` |
+
+These modes apply to both `mcp install` and `setup agent`; interactive setup offers a choice. `railway mcp proxy` remains an alias for the default proxy. The proxy may fill only a linked project ID when the tool accepts it and the call supplies no resource scope. Continue passing explicit project, environment, and service IDs for scoped work.
 
 Use Railway Agent chat with:
 
@@ -272,7 +283,7 @@ railway bucket credentials --bucket <name> --json        # S3-compatible credent
 
 ## Routing
 
-For anything beyond quick operations, load the reference that matches the user's intent. Load only what you need, one reference is usually enough, two at most.
+For anything beyond quick operations, load the references needed for the user's intent. Most requests need one or two; compose more when the workflow crosses areas.
 
 | Intent | Reference | Use for |
 |---|---|---|
@@ -280,8 +291,11 @@ For anything beyond quick operations, load the reference that matches the user's
 | Create or connect resources | [setup.md](references/setup.md) | Projects, services, databases, buckets, templates, workspaces |
 | Ship code or manage releases | [deploy.md](references/deploy.md) | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | [configure.md](references/configure.md) | Environments, variables, config patches, domains, networking |
-| Manage feature flags | [feature-flags.md](references/feature-flags.md) | List/create/update project flags via MCP; workspace flags read-only; SDK runtime reads |
-| Define configuration in source control ("IaC", "infrastructure as code", "config as code", `.railway/railway.ts`, `railway.json`, "config plan/apply/pull") | [iac.md](references/iac.md) | Choose TypeScript IaC or the `railway.json` fallback, then author, import, plan, apply, or check drift safely |
+| Manage feature flags | [feature-flags.md](references/feature-flags.md) | MCP registry operations; CLI targeting rules and rollouts; SDK runtime reads |
+| Define configuration in source control ("IaC", "infrastructure as code", "config as code", `.railway/railway.ts`, `.railway/railway.py`, `.railway/railway.go`, "config migrate/plan/apply/pull") | [iac.md](references/iac.md) | Author/import IaC, migrate legacy JSON/TOML, save and apply reviewed plans, check drift |
+| Manage databases ("PITR", "restore", "backup", "HA", "failover", "switchover", "PgBouncer", "connection pooling") | [databases.md](references/databases.md) | Postgres recovery, HA and pooling; MySQL/Redis HA; use analysis references for performance investigations |
+| Inspect costs or manage spending limits | [usage.md](references/usage.md) | Workspace/project/service usage, billing periods, workspace and Railway Agent limits |
+| Run a coding agent on Railway ("cloud agent", "railway ca", "railway code", "desktop SSH") | [cloud-agents.md](references/cloud-agents.md) | Provision, connect, wake, sleep, delete, or configure desktop access to cloud agent VMs |
 | Check health or debug failures | [operate.md](references/operate.md) | Status, logs, metrics, build/runtime triage, recovery |
 | Use a sandbox or build remotely ("sandbox", "scratch environment", "ephemeral box", "build remotely", "remote build", "run this remotely", "checkpoint", "snapshot/save/restore sandbox state") | [sandbox.md](references/sandbox.md) | Create/fork sandboxes, run commands remotely, remote template builds, checkpoints (save/restore sandbox state), port forwarding, teardown. Requires Sandboxes enabled in Priority Boarding — if unavailable, prompt the user to enable it. |
 | Request from API, docs, or community | [request.md](references/request.md) | Railway GraphQL API queries/mutations, metrics queries, Central Station, official docs |
@@ -293,12 +307,12 @@ If the request spans two areas (for example, "deploy and then check if it's heal
 1. Use Railway CLI for workflows that need the current repo, local shell, SSH, database scripts, local Railway context, or exact command output.
 2. Use Remote MCP for OAuth-scoped platform operations that match an available MCP tool and do not need local files or CLI state.
 3. Use local CLI MCP only when the current agent already has it explicitly configured and it exposes a needed operation not available through Remote MCP.
-4. Fall back to `scripts/railway-api.sh` for operations neither MCP nor CLI exposes.
+4. Use `railway api` for operations without a dedicated MCP tool or CLI command; retain the legacy helper only for CLI compatibility.
 5. Use `--json` output where available for reliable parsing.
 6. Resolve context before mutation. Know which project, environment, and service you're acting on.
 7. For destructive actions (delete service, remove deployment, drop database), confirm intent and state impact before executing.
 8. After mutations, verify the result with a read-back command or MCP read.
-9. **Never report a deploy as successful without observing a terminal SUCCESS.** `railway up --detach` returning (it prints "Build queued") and a streaming `railway up` cut off by a shell timeout only confirm the build *started*. Poll `railway deployment list --json` with the same `--project`, `--environment`, and `--service` scope used for the deploy until the newest deployment's `status` is `SUCCESS` (report deployed). If status is `FAILED` or `CRASHED`, triage per [operate.md](references/operate.md). If status is `NEEDS_APPROVAL`, `SLEEPING`, `SKIPPED`, `REMOVED`, `REMOVING`, or an unknown value, report the exact state and next action; do not claim success. A streaming `up` that exits on its own is authoritative: exit 0 = deployed, exit 1 = failed.
+9. **Never report a deploy as successful without observing SUCCESS for that deployment.** `up --detach`, a non-TTY `up` without CI mode, or a timed-out stream may return after upload. Follow the deployment ID from the upload in `railway deployment list --json` with the same project/environment/service scope; do not substitute a concurrent newer deployment. If status is `FAILED` or `CRASHED`, triage per [operate.md](references/operate.md). If status is `NEEDS_APPROVAL`, `SLEEPING`, `SKIPPED`, `REMOVED`, `REMOVING`, or unknown, report that state and the next action. Exit 0 alone is insufficient; see [deploy.md](references/deploy.md) for CI streaming and polling.
 
 ## User-only commands (NEVER execute directly)
 

--- a/plugins/railway/skills/use-railway/references/analyze-db.md
+++ b/plugins/railway/skills/use-railway/references/analyze-db.md
@@ -31,14 +31,14 @@ https://railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>/database?environme
 Then query the API for the service name and database type in a **single call**:
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'query getServiceAndConfig($serviceId: String!, $environmentId: String!) {
     service(id: $serviceId) { name }
     environment(id: $environmentId) {
       config(decryptVariables: false)
     }
   }' \
-  '{"serviceId": "<SERVICE_ID>", "environmentId": "<ENV_ID>"}'
+  --variables '{"serviceId": "<SERVICE_ID>", "environmentId": "<ENV_ID>"}'
 ```
 
 From the response, get:
@@ -57,9 +57,9 @@ Then match the image to the database type:
 **If `environmentId` is empty in the URL** (e.g., `?environmentId=` or no query param at all), skip the `environment.config` query — it requires a valid ID. Instead, list the project's environments:
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'query getEnvs($id: String!) { project(id: $id) { environments { edges { node { id name } } } } }' \
-  '{"id": "<PROJECT_ID>"}'
+  --variables '{"id": "<PROJECT_ID>"}'
 ```
 
 Use the `production` environment by default. If multiple non-PR environments exist and the user hasn't specified one, ask which environment to analyze.
@@ -257,13 +257,13 @@ All three IDs come from the URL (see "Context: URL First" above). The service na
 If the URL has no `environmentId` and the user specifies an environment by name (e.g., "production"), resolve it:
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'query getProject($id: String!) {
     project(id: $id) {
       environments { edges { node { id name } } }
     }
   }' \
-  '{"id": "<PROJECT_ID>"}'
+  --variables '{"id": "<PROJECT_ID>"}'
 ```
 
 Match the environment name (case-insensitive) to get the `environmentId`.
@@ -342,3 +342,4 @@ Railway services auto-scale CPU, RAM, and disk based on actual usage. Users do N
 
 - Docs: [ssh.md](https://docs.railway.com/cli/ssh), [logs.md](https://docs.railway.com/cli/logs), [metrics.md](https://docs.railway.com/cli/metrics), [api docs](https://docs.railway.com/api/llms-docs.md)
 - Local scripts: [analyze-postgres.py](../scripts/analyze-postgres.py), [analyze-mysql.py](../scripts/analyze-mysql.py), [analyze-redis.py](../scripts/analyze-redis.py), [analyze-mongo.py](../scripts/analyze-mongo.py), [dal.py](../scripts/dal.py)
+- API command: [api.rs (v5.49.1)](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/api.rs)

--- a/plugins/railway/skills/use-railway/references/cloud-agents.md
+++ b/plugins/railway/skills/use-railway/references/cloud-agents.md
@@ -24,9 +24,10 @@ railway ca create my-agent --project <project-id> --environment <env> --env-file
 railway ca ssh my-agent
 railway ca ssh my-agent -- bash
 railway ca start --codex --project <project-id> --environment <env>
+railway ca start --railway --project <project-id> --environment <env>
 ```
 
-Choose one creation command with the needed options. `create` provisions a VM without attaching; `ssh` connects to an existing VM and does not create one for a mistyped name. `start` can create and launch a harness, skipping the TUI. `--no-wait` on create/wake means requested, not ready: reread `ca list --json` before reporting readiness. Environment files and `--variable` inputs configure the agent VM; pass only values needed for the remote task.
+Choose one creation command with the needed options. `create` provisions a VM without attaching; `ssh` connects to an existing VM and does not create one for a mistyped name. `start` can create and launch a harness, skipping the TUI. Harness flags are `--codex`, `--claude`, `--grok`, and `--railway`; the first three carry or mint a local sign-in, while `--railway` launches Railway's own agent with credentials already on the VM and needs no local sign-in, which suits unattended workflows. `--no-wait` on create/wake means requested, not ready: reread `ca list --json` before reporting readiness. Environment files and `--variable` inputs configure the agent VM; pass only values needed for the remote task.
 
 For a human terminal, bare `railway ca` opens the management TUI and `railway code` opens a session-focused view. Automated workflows should use explicit lifecycle commands rather than attempting to control that TUI. `ca setup` configures the default harness and skills; `ca setup --show` inspects preferences and `ca setup --reset` removes them when requested. Launching can carry harness authentication and skills from the local machine, so choose the harness and remote target deliberately.
 

--- a/plugins/railway/skills/use-railway/references/cloud-agents.md
+++ b/plugins/railway/skills/use-railway/references/cloud-agents.md
@@ -1,0 +1,65 @@
+# Cloud agents
+
+Use `railway ca` / `railway code` to run coding harnesses on persistent Railway cloud agent VMs. Use `railway agent` for Railway Agent chat/investigations, and [sandbox.md](sandbox.md) for sandbox execution, builds, and checkpoints.
+
+## Availability and target
+
+Cloud agents arrived in CLI 5.32; flat lifecycle commands in 5.35 and desktop setup in 5.38. They are experimental and require **Cloud Agents** enabled in [Priority Boarding](https://railway.com/account/feature-flags). A feature-availability error calls for enabling that feature, not repeatedly provisioning VMs or changing project feature flags.
+
+Use explicit project and environment for creation. A directory's `railway link` context takes precedence over the saved default project; a stale link can fall back to the saved default. Verify the target rather than assuming the saved preference wins. Interactive `ca` can run login and continue; noninteractive unauthenticated calls fail instead of waiting on an unattended device code.
+
+```bash
+railway ca setup --show
+railway ca list --json
+railway ca list --project <project-id> --environment <env> --json
+```
+
+Bare `list` finds the user's agents across projects. `--all` includes other members' agents and requires an explicit environment. Address an existing agent by name or ID; an omitted identifier uses the directory's agent or the sole candidate, otherwise the CLI reports candidates.
+
+## Create, launch, and connect
+
+```bash
+railway ca create my-agent --project <project-id> --environment <env> --json
+railway ca create my-agent --project <project-id> --environment <env> --env-file .env.agent --json
+railway ca ssh my-agent
+railway ca ssh my-agent -- bash
+railway ca start --codex --project <project-id> --environment <env>
+```
+
+Choose one creation command with the needed options. `create` provisions a VM without attaching; `ssh` connects to an existing VM and does not create one for a mistyped name. `start` can create and launch a harness, skipping the TUI. `--no-wait` on create/wake means requested, not ready: reread `ca list --json` before reporting readiness. Environment files and `--variable` inputs configure the agent VM; pass only values needed for the remote task.
+
+For a human terminal, bare `railway ca` opens the management TUI and `railway code` opens a session-focused view. Automated workflows should use explicit lifecycle commands rather than attempting to control that TUI. `ca setup` configures the default harness and skills; `ca setup --show` inspects preferences and `ca setup --reset` removes them when requested. Launching can carry harness authentication and skills from the local machine, so choose the harness and remote target deliberately.
+
+## Sleep, wake, and delete
+
+```bash
+railway ca wake my-agent
+railway ca sleep my-agent
+railway ca delete my-agent
+```
+
+Sleep stops compute while retaining the disk; deletion removes the agent and its disk. Use sleep when the user wants to pause work and keep files. `sleep --all` acts across the user's running agents unless narrowed by environment; use it only when that broader scope was requested. Check `list --json` after lifecycle mutations. Do not mistake a disconnected harness session for a deleted VM.
+
+## Desktop SSH setup
+
+```bash
+railway ca desktop --codex --agent my-agent --dry-run
+railway ca desktop --codex --agent my-agent
+railway ca desktop --claude --agent my-agent
+```
+
+Choose the requested app; both flags can configure both on the same VM. The dry-run previews configuration. Actual setup prepares the remote harness and writes an OpenSSH entry; Claude setup also writes its desktop settings. Omitting `--agent` can create an agent when none exists. `--dir /app/api` selects the remote working directory. Restart the desktop app after setup.
+
+A desktop app cannot wake a sleeping agent through the relay: run `railway ca wake <name>` before connecting. To undo the local integration, use `railway ca desktop --codex --agent my-agent --remove` (or `--claude`); removing desktop configuration is distinct from deleting the VM.
+
+## Troubleshoot
+
+- **Wrong project**: inspect the directory link and `ca setup --show`, then use explicit scope.
+- **Access blocked**: check Cloud Agents in Priority Boarding; project feature flags do not enable it.
+- **Desktop cannot connect**: confirm the agent is awake, inspect the generated SSH host, and check CLI SSH access before rerunning setup.
+- **Session ended unexpectedly**: inspect `ca list` and reconnect to the existing agent before creating another VM.
+
+## Validated against
+
+- Docs: [Cloud agent CLI](https://docs.railway.com/cli/ca), [Code CLI](https://docs.railway.com/cli/code)
+- CLI source (v5.49.1): [cloud_agent/mod.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/cloud_agent/mod.rs), [lifecycle.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/cloud_agent/lifecycle.rs), [desktop.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/cloud_agent/desktop.rs), [setup.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/cloud_agent/setup.rs), [access.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/cloud_agent/access.rs)

--- a/plugins/railway/skills/use-railway/references/configure.md
+++ b/plugins/railway/skills/use-railway/references/configure.md
@@ -34,6 +34,21 @@ railway variable delete KEY --service <service> --environment <env>
 
 Variable changes trigger a redeployment by default. This is usually the desired behavior, since the service picks up the values on restart. Use `--skip-deploys` only when you plan to redeploy or restart separately.
 
+CLI 5.34.2+ accepts an empty assignment such as `railway variable set OPTIONAL_VALUE= --service <service>`. Empty is a value, not a deletion. Before an idempotent delete, list keys and delete only if present.
+
+### Bulk edit with a reviewed diff
+
+CLI 5.48+ opens an editor and presents the changes before applying:
+
+```bash
+railway variable edit --project <project-id> --environment <env> --service <service>
+railway variable edit --demo                 # offline fixture; no Railway mutation
+```
+
+This workflow requires a TTY or an explicitly configured `$EDITOR`/`$VISUAL`. Prefer `set`/`delete` for deterministic agent edits when no editor workflow was requested. Saving the editor is not approval: the CLI shows a redacted diff and asks before applying. Noninteractive apply requires `--yes`; deletions in agent or noninteractive sessions also require `--confirm-destructive`, within the user's approved scope.
+
+Removing a line deletes that variable. Keep `<sealed>` placeholders unchanged to preserve sealed values. Railway-provided variables are comments and cannot be edited. `--reveal` exposes plaintext in the diff; use only when intended. `--skip-deploys` commits changes without triggering deploys.
+
 ### Set sensitive values
 
 Use stdin for secrets or values that shouldn't appear in shell history:
@@ -128,7 +143,7 @@ These are set automatically at runtime. Availability depends on resource configu
 | `RAILWAY_VOLUME_MOUNT_PATH` | Filesystem path where the volume is mounted |
 | `RAILWAY_VOLUME_NAME` | Name of the attached volume |
 
-Sealed variables are write-only. Their values don't appear in CLI output.
+Sealed variables are write-only. CLI 5.47.2+ lists their names with `null` in JSON, `<sealed>` in the table, or a comment in KV output. **A null value means the sealed key already exists; do not recreate or clear it as though it were missing.** Ordinary variable output can contain plaintext secrets.
 
 ## Service config
 
@@ -356,4 +371,4 @@ While active, browser visitors must pass a check. Non-browser API clients and we
 ## Validated against
 
 - Docs: [environment.md](https://docs.railway.com/cli/environment), [variable.md](https://docs.railway.com/cli/variable), [domain.md](https://docs.railway.com/cli/domain), [tcp-proxy.md](https://docs.railway.com/cli/tcp-proxy), [private-network.md](https://docs.railway.com/cli/private-network), [outbound-network.md](https://docs.railway.com/cli/outbound-network), [cdn.md](https://docs.railway.com/cli/cdn), [waf.md](https://docs.railway.com/cli/waf)
-- CLI source: [environment/mod.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/environment/mod.rs), [environment/edit.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/environment/edit.rs), [variable.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/variable.rs), [domain.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/domain.rs), [tcp_proxy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/tcp_proxy.rs), [private_network.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/private_network.rs), [outbound_networking.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/outbound_networking.rs), [cdn.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/cdn.rs), [waf.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/waf.rs)
+- CLI source: [environment/mod.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/environment/mod.rs), [environment/edit.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/environment/edit.rs), [variable.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/variable.rs), [domain.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/domain.rs), [tcp_proxy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/tcp_proxy.rs), [private_network.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/private_network.rs), [outbound_networking.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/outbound_networking.rs), [cdn.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/cdn.rs), [waf.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/waf.rs)

--- a/plugins/railway/skills/use-railway/references/databases.md
+++ b/plugins/railway/skills/use-railway/references/databases.md
@@ -10,7 +10,7 @@ Use native CLI commands for database recovery, high availability, and connection
 | MySQL | `railway mysql ha`, `history` |
 | Redis | `railway redis ha`, `history` |
 
-Postgres operations arrived in CLI 5.33; MySQL/Redis HA in 5.46. Use **5.47.2 or newer for HA mutations** to include the revert and scaling fixes. MySQL/Redis do not expose PITR or PgBouncer commands. Availability and image eligibility also depend on Railway's engine templates; a command existing does not make every custom database image eligible.
+Postgres operations arrived in CLI 5.33; MySQL/Redis HA in 5.46. Use **5.47.1 or newer for HA mutations**: that release added the revert and scaling fixes (staged member changes, never deleting the acting primary) and `--remove-orphans`. MySQL/Redis do not expose PITR or PgBouncer commands. Availability and image eligibility also depend on Railway's engine templates; a command existing does not make every custom database image eligible.
 
 All these command trees accept `--project`, `--environment`, `--service`, and `--json`. Resolve the database service and environment first, especially when the supplied URL points at a replica or proxy. Use explicit IDs for cross-project work:
 

--- a/plugins/railway/skills/use-railway/references/databases.md
+++ b/plugins/railway/skills/use-railway/references/databases.md
@@ -1,0 +1,107 @@
+# Database operations
+
+Use native CLI commands for database recovery, high availability, and connection pooling. Use [analyze-db.md](analyze-db.md) for performance analysis and [setup.md](setup.md) to create a database or connect a local client.
+
+## Choose the engine and scope
+
+| Engine | Commands |
+|---|---|
+| Postgres | `railway postgres pitr`, `ha`, `pgbouncer`, `history` |
+| MySQL | `railway mysql ha`, `history` |
+| Redis | `railway redis ha`, `history` |
+
+Postgres operations arrived in CLI 5.33; MySQL/Redis HA in 5.46. Use **5.47.2 or newer for HA mutations** to include the revert and scaling fixes. MySQL/Redis do not expose PITR or PgBouncer commands. Availability and image eligibility also depend on Railway's engine templates; a command existing does not make every custom database image eligible.
+
+All these command trees accept `--project`, `--environment`, `--service`, and `--json`. Resolve the database service and environment first, especially when the supplied URL points at a replica or proxy. Use explicit IDs for cross-project work:
+
+```bash
+railway postgres pitr status --project <project-id> --environment <env> --service <service> --json
+railway postgres ha status --project <project-id> --environment <env> --service <service> --json
+railway postgres pgbouncer status --project <project-id> --environment <env> --service <service> --json
+railway mysql ha status --project <project-id> --environment <env> --service <service> --json
+railway redis ha status --project <project-id> --environment <env> --service <service> --json
+```
+
+The following examples abbreviate scope to `--service`; retain the resolved project and environment in actual calls. Config-changing actions deploy by default. Where supported, `--no-deploy` commits config but defers its runtime effect until the affected services deploy; it is not a dry-run. Use it only when deployment is deliberately deferred. Add `--yes` only for a mutation whose scope and impact the user authorized, and only where the command supports it.
+
+## Postgres point-in-time recovery
+
+```bash
+railway postgres pitr status --service <postgres> --json
+railway postgres pitr enable --service <postgres>
+railway postgres pitr disable --service <postgres>
+railway postgres pitr progress --service <postgres> --json
+railway postgres pitr progress --service <postgres> --watch
+```
+
+`enable`/`disable` recognize a standalone database or an HA cluster root. Standalone operations support `--no-deploy`; HA enable/disable runs a live rolling workflow. `progress`, `cancel`, and `clear` apply only to that HA workflow. Inspect progress before canceling a stuck workflow; clear a completed snapshot only when intended. Bound a watch process and report its last observed phase if it times out.
+
+Status includes a best-effort SSH probe of archive coverage and archiver health. `unavailable` or unknown probe results do not mean backups are disabled or healthy. Resolve SSH reachability or report the missing evidence.
+
+To restore to a separate service:
+
+```bash
+railway postgres pitr restore --service <postgres> --at 2026-09-04T10:00:00Z --new-service-name postgres-restored
+```
+
+Use an explicit UTC timestamp to avoid local-time ambiguity. Relative offsets such as `30m` are also accepted. Check available coverage first, then verify the restored service's deployment and data before changing application connection variables. `--source-repo-path` selects an archive history when needed. Creating a restored service does not itself switch application traffic.
+
+### Backups and schedules
+
+```bash
+railway postgres pitr backup list --service <postgres> --json
+railway postgres pitr backup create --service <postgres> --name pre-migration
+railway postgres pitr backup lock <backup-id> --service <postgres>
+railway postgres pitr schedule list --service <postgres> --json
+railway postgres pitr schedule set --daily --weekly --service <postgres>
+railway postgres pitr backup restore <backup-id> --service <postgres>
+railway postgres pitr backup delete <backup-id> --service <postgres>
+```
+
+`backup restore` overwrites the current data; it is different from `pitr restore`, which creates a new service. In-place backup restore on an HA cluster is rejected because replicas would diverge; use the dashboard workflow that reseeds replicas. Do not bypass the guard by restoring the root volume manually. `backup lock` keeps a backup indefinitely. `schedule set --none` removes automatic schedules while keeping existing backups. Verify the backup ID, target, and destructive impact before restore/delete.
+
+## High availability
+
+```bash
+railway postgres ha convert --service <postgres> --replicas 2 --coordinators 3 --edge 1
+railway postgres ha scale --service <postgres> --replicas 3
+railway postgres ha switchover --service <postgres> --to <replica-name-or-id>
+railway postgres ha revert --service <postgres>
+railway mysql ha convert --service <mysql> --replicas 2
+railway mysql ha scale --service <mysql> --replicas 4
+railway redis ha convert --service <redis> --replicas 2
+railway redis ha switchover --service <redis> --to <replica-name-or-id>
+```
+
+`--replicas` counts replicas **excluding the primary**. Omitted conversion counts preserve the template defaults. MySQL and Redis carry consensus on their data nodes: total data nodes must be odd and at least three, so pass an even replica count such as 2 or 4. These conversions require a source image tagged with an exact major.minor version. Separate `--coordinators` applies only to templates with that tier; its count must be odd. Follow the template's reported constraints rather than copying a Postgres topology to another engine.
+
+Before scaling or switching, inspect live member roles and probe errors. Switchover requires a reachable eligible target and may briefly interrupt connections. After conversion/scale/switchover, reread HA status and verify primary role, replica health, and application connectivity; a committed config alone is not evidence that replication is healthy.
+
+Revert returns the database to standalone and removes cluster members. Current CLI fixes protect the acting primary and retain the independent PgBouncer pooler. `--remove-orphans` is a separate cleanup opt-in: orphaned members may no longer identify which same-engine cluster owned them. Do not add it merely to make a retry succeed. If an operation fails midway, inspect current config, live roles, and history before retrying or cleaning up.
+
+## Postgres connection pooling
+
+```bash
+railway postgres pgbouncer status --service <postgres> --json
+railway postgres pgbouncer add --service <postgres> --pool-mode transaction
+railway postgres pgbouncer configure --service <postgres> --max-client-conn 200
+railway postgres pgbouncer scale --service <postgres> --replicas 2
+railway postgres pgbouncer remove --service <postgres>
+```
+
+Pooling works with standalone Postgres and HA roots. Modes are `transaction`, `session`, and `statement`; choose based on the application's session/transaction requirements. Check utilization and existing limits before changing connection counts. Verify the pooler's deployment and connection endpoint before wiring the app to it; removing the pooler requires restoring a suitable application connection path.
+
+## Verify and investigate
+
+```bash
+railway postgres history --service <postgres> --limit 10 --json
+railway mysql history --service <mysql> --limit 10 --json
+railway redis history --service <redis> --limit 10 --json
+```
+
+History is a **local** operation trail, not a complete account audit log. Pair it with fresh native status, scoped deployment status, and logs. Do not infer that no changes happened just because this machine has no history. Follow [operate.md](operate.md) for deployment/log triage and [analyze-db.md](analyze-db.md) for deeper queries.
+
+## Validated against
+
+- Docs: [Postgres CLI](https://docs.railway.com/cli/postgres)
+- CLI source (v5.49.1): [postgres.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/postgres.rs), [mysql.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/mysql.rs), [redis.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/redis.rs), [pitr.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/database/pitr.rs), [ha.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/database/ha.rs), [pool.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/database/pool.rs), [ops_log.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/database/ops_log.rs)

--- a/plugins/railway/skills/use-railway/references/deploy.md
+++ b/plugins/railway/skills/use-railway/references/deploy.md
@@ -10,11 +10,11 @@ Ship code, manage releases, and configure builds.
 railway up --detach -m "<release summary>"
 ```
 
-`--detach` (alias `--no-wait`) returns immediately instead of streaming build logs. Without it, the deploy blocks execution until the build finishes. Always include `-m` with a release summary for auditability.
+`--detach` (alias `--no-wait`) returns after upload without waiting for the deployment. An existing-project `up` also returns after upload when stdout is not a TTY and neither `--ci`, `--json`, nor CI environment mode is active. Do not assume omitting `--detach` makes an agent invocation wait. Include `-m` with a release summary for auditability.
 
 ### Verify before reporting — `--detach` only means QUEUED
 
-A detached `up` returns when the build is **queued**, not deployed. Never tell the user their app is deployed based on `--detach` output (or a streaming `up` that your shell timed out). Poll until the newest deployment reaches a terminal state:
+A detached `up` confirms upload, not a successful deployment. Capture the deployment ID from the upload (`--detach --json` includes `deploymentId` for an authenticated deployment). Poll for that deployment's terminal state; do not mistake a concurrent newer deployment for the one just submitted:
 
 ```bash
 railway deployment list --service <service> --environment <environment> --json    # newest first; check .status
@@ -29,7 +29,7 @@ Poll with the same project, environment, and service scope used for `railway up`
 - `FAILED` / `CRASHED` → do not report success. Pull scoped logs (`railway logs --service <service> --json --lines 100`) and triage per [operate.md](operate.md).
 - `SLEEPING` / `SKIPPED` / `REMOVED` / `REMOVING` / unknown → do not report success. Report the exact state and inspect status/logs to decide the next action.
 
-A non-detached `railway up` streams to completion and its exit code is authoritative: 0 = SUCCESS, 1 = FAILED/CRASHED. If it was killed or timed out before printing a terminal status, treat the outcome as unknown and poll as above.
+Observe `SUCCESS` for the submitted deployment before claiming success. Exit 0 can mean upload returned early or watch patterns skipped the build. A timeout, ended stream, or transport error without a deployment verdict leaves the outcome unknown; poll the existing deployment before deciding whether a retry is necessary.
 
 ### Watch the build
 
@@ -37,7 +37,7 @@ A non-detached `railway up` streams to completion and its exit code is authorita
 railway up --ci -m "<release summary>"
 ```
 
-`--ci` streams build logs and exits when the build completes. Use this when the user wants to see build output or when you need to triage build failures immediately.
+`--ci` streams build logs and waits for the deployment verdict; `--json` also enables CI behavior for authenticated deployments. On CLI 5.41+, failed build-log/status WebSocket connections fall back to HTTP status polling in CI mode. A log transport warning alone does not mean the deployment failed; let the verdict arrive or query its ID. Use a bounded process timeout because polling may outlive missing deployments or nonterminal states. `--ci` can exit 0 when no changed files match watch patterns, so report a skipped deployment accurately.
 
 ### Targeted deploy
 
@@ -222,4 +222,4 @@ railway environment edit --service-config <service> build.watchPatterns '["packa
 ## Validated against
 
 - Docs: [up.md](https://docs.railway.com/cli/up), [deploying.md](https://docs.railway.com/cli/deploying), [deployment.md](https://docs.railway.com/cli/deployment), [redeploy.md](https://docs.railway.com/cli/redeploy), [service.md](https://docs.railway.com/cli/service), [down.md](https://docs.railway.com/cli/down), [railpack.md](https://docs.railway.com/builds/railpack), [monorepo.md](https://docs.railway.com/deployments/monorepo)
-- CLI source: [up.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/up.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/deployment.rs), [down.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/down.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/redeploy.rs), [restart.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/restart.rs), [service.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/service.rs)
+- CLI source: [up.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/up.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/deployment.rs), [down.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/down.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/redeploy.rs), [restart.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/restart.rs), [service.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/service.rs)

--- a/plugins/railway/skills/use-railway/references/feature-flags.md
+++ b/plugins/railway/skills/use-railway/references/feature-flags.md
@@ -61,11 +61,11 @@ Types are inferred unless `--type bool|string|number|json` is given. `--force` p
 For API operations beyond these commands, inspect the public GraphQL API (`signals`, `signalCreate`, `signalDefaultSet`, `signalRuleSet`, `signalDelete`) using [request.md](request.md). Owners use `project:<projectId>` or `workspace:<workspaceId>`; access remains subject to the API's scope and permission checks.
 
 ```bash
-railway api --variables '{"owner":"project:<projectId>"}' <<'EOF'
-query projectSignals($owner: String!) {
-  signals(owner: $owner) { name type default rules version }
-}
-EOF
+railway api \
+  'query projectSignals($owner: String!) {
+    signals(owner: $owner) { name type default rules version }
+  }' \
+  --variables '{"owner":"project:<projectId>"}'
 ```
 
 ## Runtime SDK

--- a/plugins/railway/skills/use-railway/references/feature-flags.md
+++ b/plugins/railway/skills/use-railway/references/feature-flags.md
@@ -35,26 +35,33 @@ List feature flags for project 6adb5ae3-0e3a-4ead-b42c-1fd36f217ffb
 Set feature flag checkout-v2 on project 6adb5ae3-0e3a-4ead-b42c-1fd36f217ffb to true (bool)
 ```
 
-For targeting rules and rollouts, use the dashboard UI or GraphQL (`signalRuleSet`) until MCP rule tools exist.
+For targeting rules and rollouts, use the CLI commands below when MCP has no matching rule tool. The dashboard or GraphQL (`signalRuleSet`) remains a fallback.
 
-## CLI (when available)
+## CLI defaults, rules, and rollouts
 
-The Railway CLI exposes `railway flag` (alias `railway signal`) for registry CRUD. Upgrade the CLI if the command is missing:
+CLI 5.24+ exposes `railway flag` (alias `railway flags`). Use `--scope project:<id>` for explicit targeting; `--project` is not a flag option. On 5.26.2+, omitted scope can come from the project token or linked project.
 
 ```bash
-railway upgrade --yes
-railway flag list --project <project-id> --json
-railway flag checkout-v2 true --project <project-id>
+railway flag list --scope project:<project-id> --json
+railway flag list --scope project:<project-id> --full
+railway flag set checkout-v2 true --scope project:<project-id>
+railway flag set theme blue --type string --scope project:<project-id>
+railway flag set checkout-v2 true --scope project:<project-id> --when 'plan == "enterprise"' --rule-id enterprise
+railway flag set checkout-v2 true --scope project:<project-id> --when 'bucket(key) < 0.25' --rule-id rollout-25
+railway flag unset checkout-v2 --scope project:<project-id> --rule-id enterprise
+railway flag delete checkout-v2 --scope project:<project-id>
 ```
 
-Use `--project` (or link first) so scope is explicit in agent workflows.
+`set` changes the default unless `--when` is supplied. Rules accept a CEL expression subset or raw JSON; `bucket(key)` gives deterministic percentage targeting using the evaluation context's key. Use a stable `--rule-id` when updating a rule, and list/read back the rules afterward. `unset` removes one rule; `delete` removes the entire flag. CLI mutations target project flags; do not assume workspace mutation support.
+
+Types are inferred unless `--type bool|string|number|json` is given. `--force` permits replacing a flag's type and **clears its rules**; use it only when that replacement is intended.
 
 ## GraphQL fallback
 
-When MCP and CLI are unavailable, use the public GraphQL API (`signals`, `signalCreate`, `signalDefaultSet`, `signalRuleSet`, `signalDelete`) with owner `project:<projectId>` or `workspace:<workspaceId>`. See https://docs.railway.com/docs/feature-flags
+For API operations beyond these commands, inspect the public GraphQL API (`signals`, `signalCreate`, `signalDefaultSet`, `signalRuleSet`, `signalDelete`) using [request.md](request.md). Owners use `project:<projectId>` or `workspace:<workspaceId>`; access remains subject to the API's scope and permission checks.
 
 ```bash
-scripts/railway-api.sh '{"owner":"project:<projectId>"}' <<'EOF'
+railway api --variables '{"owner":"project:<projectId>"}' <<'EOF'
 query projectSignals($owner: String!) {
   signals(owner: $owner) { name type default rules version }
 }
@@ -87,3 +94,8 @@ Poll interval defaults are suitable for most apps; flags refresh when registry v
 ## Dashboard
 
 Human-friendly CRUD: open the project → **Settings → Feature Flags**. Workspace-scoped flags appear in a read-only section when they exist.
+
+## Validated against
+
+- Docs: [Feature flags](https://docs.railway.com/feature-flags), [CLI flags](https://docs.railway.com/cli/flag)
+- CLI source (v5.49.1): [flag.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/flag.rs), [signals.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/controllers/signals.rs)

--- a/plugins/railway/skills/use-railway/references/iac.md
+++ b/plugins/railway/skills/use-railway/references/iac.md
@@ -4,7 +4,7 @@ Use Infrastructure as Code for project configuration. Keep one authoring file an
 
 ## Choose the model
 
-TypeScript IaC is generally available. Python and Go authoring are in beta. Preserve an existing `.railway/railway.ts`, `.railway/railway.py`, or `.railway/railway.go`; do not switch languages based on the app's `package.json`, `go.mod`, or framework. With no existing authoring file, `config init` and `config pull` default to TypeScript even for non-TypeScript apps. Honor an explicit Python/Go preference using the matching SDK and one authoring file.
+TypeScript IaC is generally available. Python and Go authoring are in beta. Preserve an existing `.railway/railway.ts`, `.railway/railway.py`, or `.railway/railway.go`; do not switch languages based on the app's `package.json`, `go.mod`, or framework. With no existing authoring file, `config init` and `config pull` default to TypeScript even for non-TypeScript apps. `config init` and `config pull` have no language flag: the CLI picks the language only from an existing authoring file. To honor an explicit Python/Go preference on a fresh project, create an empty `.railway/railway.py` or `.railway/railway.go` first, then run `config pull` so the import is emitted in that language. `config migrate --lang py|go` emits Python/Go only when translating legacy `railway.json`/`railway.toml`.
 
 `railway.json` and `railway.toml` are deprecated. New services cannot opt into Config as Code; existing files stop being read on **2026-12-01**. Do not create them as a fallback. For an existing legacy service, use the migration workflow below; if the user requests a temporary legacy edit, explain the cutoff and keep its current format.
 
@@ -238,9 +238,9 @@ Before completing the migration:
 - Run `railway config plan`; inspect unexpected removals or changes, then apply only within the user's authorized scope.
 - Check for remaining legacy files and custom Railway Config File paths so deployments do not retain dual ownership.
 
-For a requested temporary edit to an existing legacy service, retain its format, validate against the [Config as Code reference](https://docs.railway.com/reference/config-as-code), and explain the 2026-12-01 cutoff. Config as Code has deployment-time precedence over dashboard settings; a deployment is needed for edits to take effect. Keep variables and secrets in Railway variables.
+For a requested temporary edit to an existing legacy service, retain its format, validate against the [Config as Code reference](https://docs.railway.com/config-as-code/reference), and explain the 2026-12-01 cutoff. Config as Code has deployment-time precedence over dashboard settings; a deployment is needed for edits to take effect. Keep variables and secrets in Railway variables.
 
 ## Validated against
 
-- Docs: [Infrastructure as Code](https://docs.railway.com/infrastructure-as-code), [IaC reference](https://docs.railway.com/infrastructure-as-code/reference), [Config as Code](https://docs.railway.com/guides/config-as-code)
+- Docs: [Infrastructure as Code](https://docs.railway.com/infrastructure-as-code), [IaC reference](https://docs.railway.com/infrastructure-as-code/reference), [Config as Code](https://docs.railway.com/config-as-code)
 - CLI source (v5.49.1): [config/mod.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/config/mod.rs), [config/migrate.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/config/migrate.rs), [authoring.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/config/authoring.rs), [eval.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/iac/eval.rs), [saved_plan.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/iac/saved_plan.rs)

--- a/plugins/railway/skills/use-railway/references/iac.md
+++ b/plugins/railway/skills/use-railway/references/iac.md
@@ -1,65 +1,62 @@
 # Configuration in source control
 
-Choose one configuration model before editing files. Never manage the same service with both models.
+Use Infrastructure as Code for project configuration. Keep one authoring file and never manage a service with both IaC and legacy Config as Code.
 
 ## Choose the model
 
-Prefer TypeScript Infrastructure as Code when the repository has TypeScript set up. Use `railway.json` only as the fallback for repositories without TypeScript.
+TypeScript IaC is generally available. Python and Go authoring are in beta. Preserve an existing `.railway/railway.ts`, `.railway/railway.py`, or `.railway/railway.go`; do not switch languages based on the app's `package.json`, `go.mod`, or framework. With no existing authoring file, `config init` and `config pull` default to TypeScript even for non-TypeScript apps. Honor an explicit Python/Go preference using the matching SDK and one authoring file.
 
-Use TypeScript IaC when any of these signals exist in the current project or workspace:
-
-- `.railway/railway.ts` already exists.
-- A `tsconfig.json` or another `tsconfig*.json` exists.
-- `package.json` declares `typescript`, or the project contains `.ts` or `.tsx` source files.
-
-If none of those signals exist, create or edit `railway.json`. Do not choose `railway.toml` for new agent-authored configuration.
-
-If a TypeScript repository already has `railway.json`, migrate the intended settings to `.railway/railway.ts` and remove the old file before planning. If the user explicitly asks to preserve the existing model rather than migrate, edit the existing file and explain that it remains service-level Config as Code.
-
-The models have different scopes:
+`railway.json` and `railway.toml` are deprecated. New services cannot opt into Config as Code; existing files stop being read on **2026-12-01**. Do not create them as a fallback. For an existing legacy service, use the migration workflow below; if the user requests a temporary legacy edit, explain the cutoff and keep its current format.
 
 | Model | Scope | Applies when |
 |---|---|---|
-| `.railway/railway.ts` | Whole Railway project: services, databases, buckets, volumes, variables, replicas, domains, and canvas groups | `railway config apply` applies the reviewed project plan |
-| `railway.json` | One service's build and deploy settings | The next deployment reads the file; it does not update dashboard settings |
+| `.railway/railway.ts`, `.py`, or `.go` | Project/environment: services, databases, buckets, volumes, variables, replicas, domains, and canvas groups | `railway config apply` applies the project plan |
+| Existing `railway.json` / `railway.toml` | One legacy service's build and deploy settings | Read during deployments until the cutoff; overrides dashboard values for that deployment |
 
-## TypeScript Infrastructure as Code
+## Infrastructure as Code
 
-The desired Railway project state lives in:
+Keep exactly one of these files:
 
 ```text
 .railway/railway.ts
+.railway/railway.py
+.railway/railway.go
 ```
 
 `railway config init` and `railway config pull` also create `.railway/README.md`. Railway agent setup installs the shared `use-railway` skill; config commands do not need or create a project-local skill.
 
+Install the matching authoring package in the config's package environment: `npm install railway`, `pip install railway-sdk`, or `go get github.com/railwayapp/railway-go-sdk`. Python/Go imports can generate `.railway/requirements.txt` or `.railway/go.mod`; use those when present. CLI 5.42+ evaluates the graph natively, but still needs the language runtime and SDK to evaluate authoring code. `--runner` is an optional legacy TypeScript runner override, not a prerequisite.
+
 ### Core rules
 
 1. Express Railway product intent, not internal API details.
-2. Do not write Railway UUIDs into `.railway/railway.ts`.
+2. Do not write Railway UUIDs into the authoring file.
 3. Do not write `EnvironmentConfigPatch`, `ServiceInstance`, Backboard internals, or generated Railway domains into source.
 4. Prefer helpers such as `service()`, `postgres()`, `redis()`, `mysql()`, `mongo()`, `bucket()`, `volume()`, `group()`, `github()`, and `image()`.
 5. Use `service.env.VARIABLE` and `database.env.VARIABLE` for references.
-6. Keep secrets out of source. Imported unknown secret values should use `preserve()` or be omitted when the user wants a smaller import.
+6. Keep secrets out of source. Imports use `preserve()` by default for existing variables; omit them only when a smaller import is intended.
 7. Prefer product DSL names such as `domains`, `replicas`, and `group`; avoid internal names such as `customDomains` and `multiRegionConfig`.
 8. Do not add platform defaults unless the user explicitly wants them.
-9. After editing `.railway/railway.ts`, run `railway config plan`.
+9. After editing the authoring file, run `railway config plan`.
 10. Do not run `railway config apply` unless the user explicitly asks.
 11. Never use `railway config apply --yes` or `--confirm-destructive` from an agent session without explicit user approval for the exact plan.
 
 ### Initialize or import
 
 ```bash
-railway config init                         # create .railway/railway.ts
+railway config init                         # TypeScript by default; preserve existing language
 railway config init --force                 # overwrite existing generated files
 railway config pull                         # import the linked project
-railway config pull --force                 # overwrite existing .railway/railway.ts
+railway config pull --force                 # overwrite the existing authoring file
 railway config pull --omit-preserved-variables # omit unknown variable values
 railway config pull --json                  # print current graph instead of writing files
 railway config pull --agent                 # ask an agent to clean the import afterward
+railway config pull --include-variables     # decrypt and inline non-sealed values
 ```
 
-If the directory is not linked, the CLI prompts for project and environment in an interactive terminal. In agent workflows, link first or pass explicit project and environment context when supported.
+Use `--include-variables` only when writing those values to source is intended: it includes non-sealed secrets too. Sealed values remain `preserve()`. A normal import should produce a no-change plan; inspect any diff before applying.
+
+Plan/apply discover the nearest `.railway/railway.{ts,py,go}` by walking up from the current directory. `--file <path>` overrides that selection. Run init/pull/migrate from the intended project root. Config commands do not expose `--project`/`--environment` selectors: verify the link or use `railway link --project <id> --environment <env>` before noninteractive work. Interactive commands can prompt for missing context.
 
 ### Authoring
 
@@ -91,6 +88,7 @@ const db = postgres("postgres");
 const api = service("api", {
   source: github("owner/repo", { branch: "main" }),
   build: "pnpm build",
+  preDeploy: "pnpm db:migrate",
   start: "pnpm start",
   env: {
     DATABASE_URL: db.env.DATABASE_URL,
@@ -170,7 +168,20 @@ railway config apply --yes --confirm-destructive
 railway config apply --json --yes --confirm-destructive
 ```
 
-`apply` runs a fresh plan. If remote state changed, Railway rejects the stale apply and requires another plan. In non-interactive or agent sessions, destructive changes require `--confirm-destructive` in addition to `--yes` or `--json`; add it only after the user explicitly approves the exact destructive impact.
+Ordinary `apply` evaluates a fresh plan. Changes to the environment between planning inside that invocation and applying are rejected. In non-interactive or agent sessions, destructive changes require `--confirm-destructive` in addition to `--yes` or `--json`; add it only after the user explicitly approves the exact destructive impact.
+
+### Apply the reviewed plan in CI
+
+CLI 5.45.1+ can save the evaluated change set and apply that exact artifact:
+
+```bash
+railway config plan --out railway-plan.json
+railway config apply --plan railway-plan.json --yes
+```
+
+Review the first command's diff before authorizing the apply. Store the artifact outside `.railway/` because that directory's source tree is pinned. The artifact contains the change set, environment ID and config etag, and source tree identity. `apply --plan` does not reevaluate the authoring code; it rejects changed source or remote state rather than quietly generating another plan. Keep the same CLI version and source checkout between jobs. Use `--source-tree` on `plan` only when CI deliberately supplies the source identity. Treat plan artifacts as potentially secret-bearing even when terminal diffs are redacted.
+
+When a saved plan is stale, create and review a replacement. Destructive saved plans still require `--confirm-destructive`. For maintained CI integration, use [railwayapp/config](https://github.com/railwayapp/config).
 
 ### Review checklist
 
@@ -184,74 +195,52 @@ Before applying, confirm:
 - Scaling uses `replicas`, not `multiRegionConfig`.
 - No generated Railway service domains or Railway UUIDs are committed.
 
-### Troubleshoot TypeScript IaC
+### Troubleshoot IaC
 
-- **Service is already managed by `railway.json`**: migrate its intended settings and remove the old file before planning; Railway blocks dual ownership.
+- **Service is already managed by Config as Code**: use migration below; deleting the file alone does not clear its Railway Config File setting.
 - **Plan shows secrets as hidden**: expected. Use `--show-values` only with user approval.
 - **Apply says the plan is stale**: run a new plan, inspect it, then apply again only if requested.
 - **Destructive apply is blocked**: get explicit approval for the exact plan before adding `--confirm-destructive`.
-- **Imported variables use `preserve()`**: Railway could not safely print encrypted values; `preserve()` retains the remote value.
-- **Generated code is too literal**: simplify `.railway/railway.ts`, then run another plan.
+- **Imported variables use `preserve()`**: this is the default, including readable values; it retains the remote value without putting it into source.
+- **Missing Railway package**: install the SDK for the existing authoring language in its runtime environment; do not replace the config language to work around the error.
+- **Generated code is too literal**: simplify the authoring file, then run another plan.
 
-## `railway.json` fallback
+## Migrate legacy Config as Code
 
-Use this path only when the repository has no TypeScript setup. `railway.json` controls one service's build and deploy settings, not project resources such as databases, buckets, variables, or canvas groups.
+Use CLI **5.49.1 or newer**: its TypeScript migration and all-language pull fixes preserve `preDeployCommand` as the first-class `preDeploy` field. Earlier TypeScript migration output could silently omit a database migration command.
 
-Start with the schema so editors validate fields:
+Start with a dry-run from the repository root:
 
-```json
-{
-  "$schema": "https://railway.com/railway.schema.json",
-  "build": {
-    "builder": "RAILPACK",
-    "buildCommand": "npm run build"
-  },
-  "deploy": {
-    "preDeployCommand": ["npm run db:migrate"],
-    "startCommand": "npm start",
-    "healthcheckPath": "/health",
-    "healthcheckTimeout": 300,
-    "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 5
-  }
-}
+```bash
+railway config migrate
+railway config migrate --service api
+railway config migrate --lang py
+railway config migrate --lang go
 ```
 
-Rules for this fallback:
+The default emits proposed TypeScript without writing files or clearing remote settings. `--service` selects a service when multiple configs are found; with one file it can name the emitted service. Inspect the discovered paths and service mapping in a monorepo. Single-service migration may emit a named partial rather than claim the whole project; retain that ownership boundary when merging it into existing IaC.
 
-1. Include only settings the user intends to override. File values override dashboard values for that deployment.
-2. Use the canonical schema field names; do not copy internal environment patch names blindly.
-3. Keep service variables and secrets out of `railway.json`; manage them with Railway variables.
-4. Use `environments.<name>` for environment-specific overrides and `environments.pr` for PR environments.
-5. In a monorepo, place the file at the service root or set the service's custom Railway config file path to its absolute repository path.
-6. Validate the JSON after editing. A deployment is required for the config to take effect; editing the file does not mutate dashboard settings.
+In v5.49.1, Python/Go **migration** emits only build/start commands and the healthcheck path. Manually carry over other intended settings, including pre-deploy commands, replicas, and healthcheck timeouts, before applying the resulting IaC. A successful migration command is not proof of a lossless translation in any language; compare the original files and plan.
 
-Example environment override:
+For an authorized migration, write the result and clear the discovered services' Railway Config File settings:
 
-```json
-{
-  "$schema": "https://railway.com/railway.schema.json",
-  "deploy": {
-    "startCommand": "npm start"
-  },
-  "environments": {
-    "staging": {
-      "deploy": {
-        "startCommand": "npm run staging"
-      }
-    },
-    "pr": {
-      "deploy": {
-        "startCommand": "npm run preview"
-      }
-    }
-  }
-}
+```bash
+railway config migrate --apply
+railway config migrate --apply --delete-files
 ```
 
-For the complete field list, use the live JSON schema or Railway's Config as Code reference rather than guessing unsupported keys.
+`--apply` here writes source and changes remote config-file settings; it does **not** apply the resulting IaC project plan. `--delete-files` additionally removes discovered legacy files and requires `--apply`. If an authoring file already exists, merge the dry-run output into it instead of using `--force` to overwrite unrelated resources. Preserve the language with `--lang` when needed; migration defaults to `ts`.
+
+Before completing the migration:
+
+- Compare build/start/pre-deploy commands, health checks, regions/replicas, and environment overrides with the original files. Do not assume every legacy field was translated.
+- Preserve secrets and review the service identities and ownership scope.
+- Run `railway config plan`; inspect unexpected removals or changes, then apply only within the user's authorized scope.
+- Check for remaining legacy files and custom Railway Config File paths so deployments do not retain dual ownership.
+
+For a requested temporary edit to an existing legacy service, retain its format, validate against the [Config as Code reference](https://docs.railway.com/reference/config-as-code), and explain the 2026-12-01 cutoff. Config as Code has deployment-time precedence over dashboard settings; a deployment is needed for edits to take effect. Keep variables and secrets in Railway variables.
 
 ## Validated against
 
-- Docs: [Infrastructure as Code](https://docs.railway.com/infrastructure-as-code), [IaC reference](https://docs.railway.com/infrastructure-as-code/reference), [Config as Code](https://docs.railway.com/guides/config-as-code), [Config as Code reference](https://docs.railway.com/reference/config-as-code)
-- CLI source: [config/mod.rs](https://github.com/railwayapp/cli/blob/v5.27.1/src/commands/config/mod.rs), [config/runner.rs](https://github.com/railwayapp/cli/blob/v5.27.1/src/commands/config/runner.rs)
+- Docs: [Infrastructure as Code](https://docs.railway.com/infrastructure-as-code), [IaC reference](https://docs.railway.com/infrastructure-as-code/reference), [Config as Code](https://docs.railway.com/guides/config-as-code)
+- CLI source (v5.49.1): [config/mod.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/config/mod.rs), [config/migrate.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/config/migrate.rs), [authoring.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/config/authoring.rs), [eval.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/iac/eval.rs), [saved_plan.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/iac/saved_plan.rs)

--- a/plugins/railway/skills/use-railway/references/operate.md
+++ b/plugins/railway/skills/use-railway/references/operate.md
@@ -79,7 +79,7 @@ HTTP filter fields include `@method`, `@path`, `@host`, `@requestId`, `@srcIp`, 
 
 ### Network flow logs
 
-Use network flow logs for private networking, TCP proxy, outbound allowlist, DNS, or dropped-packet investigations:
+Use network flow logs for private networking, TCP proxy, outbound allowlist, or dropped-packet investigations. Use DNS query logs below for resolution results:
 
 ```bash
 railway logs --service <service> --network --lines 100 --json
@@ -103,6 +103,20 @@ Useful filters:
 | `--port <port>` | Source or destination port |
 | `--src`, `--dst`, `--host` | IP filters |
 | `--drop-cause <cause>` | Drop reason |
+
+### DNS query logs
+
+CLI 5.29+ exposes DNS resolution results directly:
+
+```bash
+railway logs --service <service> --environment <env> --dns --lines 100 --json
+railway logs --service <service> --dns --status failed --since 1h --lines 100 --json
+railway logs --service <service> --dns --rcode NXDOMAIN --lines 100 --json
+railway logs --service <service> --dns --qname backend.railway.internal --zone internal --lines 50 --json
+railway logs --service <service> --dns --domain example.com --qtype AAAA --lines 100 --json
+```
+
+Use `--qname` for the full query name, `--domain` for domain filtering, `--qtype` for record type, `--rcode` for DNS response code, and `--zone internal|external` for lookup scope. `--status failed` finds failed resolutions. DNS logs are service-level and mutually exclusive with build, deployment, HTTP, and network modes; do not pass a deployment ID or `--latest`. Correlate failed lookups with runtime errors and network flows instead of treating a DNS failure as an application crash.
 
 ## Metrics
 
@@ -155,6 +169,8 @@ For database-level metrics and introspection, use the analysis scripts. `railway
 - HA cluster checks (Patroni, etcd, HAProxy)
 - Redis, MySQL, and MongoDB introspection
 - Combined analysis via `scripts/analyze-<type>.py` (postgres, mysql, redis, mongo)
+
+For native PITR/HA/PgBouncer status and operations, use [databases.md](databases.md). For billed usage and spending limits, use [usage.md](usage.md); infrastructure metrics are not a billing statement.
 
 ## Failure triage
 
@@ -259,6 +275,10 @@ Always verify after fixing. Don't assume the redeploy succeeded.
 
 ## Troubleshoot common blockers
 
+- **`OAUTH_INSUFFICIENT_GRANT` / resource access denied**: CLI 5.37.4+ distinguishes a live OAuth session without access from an expired login. Check the resource IDs, workspace membership, and integration grant scope; repeating the same login may retain the same insufficient grant. Reauthorize with the necessary access only when the user intends that scope.
+- **Expired or invalid credentials**: follow the CLI's login/token-specific error. Transient refresh failures are not proof that access was revoked. Newer CLI versions refresh long-lived clients too; upgrade an old CLI before repeatedly reinstalling MCP to address stale authentication.
+- **CI log stream failed**: on CLI 5.41+, the command falls back to status polling. Inspect the submitted deployment before retrying; a logging error alone is not a deployment failure.
+
 - **Unlinked context**: `railway link --project <id-or-name>`
 - **Missing service scope for logs**: pass `--service` and `--environment` explicitly
 - **Wrong project in status or deploy polling**: pass `--project`, `--environment`, and `--service`; URL IDs beat local linked context
@@ -270,4 +290,5 @@ Always verify after fixing. Don't assume the redeploy succeeded.
 ## Validated against
 
 - Docs: [status.md](https://docs.railway.com/cli/status), [service.md](https://docs.railway.com/cli/service), [logs.md](https://docs.railway.com/cli/logs), [metrics.md](https://docs.railway.com/cli/metrics), [ssh.md](https://docs.railway.com/cli/ssh), [cdn.md](https://docs.railway.com/cli/cdn), [waf.md](https://docs.railway.com/cli/waf), [observability/logs.md](https://docs.railway.com/observability/logs), [observability/metrics.md](https://docs.railway.com/observability/metrics)
-- CLI source: [status.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/status.rs), [service.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/service.rs), [logs.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/logs.rs), [metrics.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/metrics.rs), [ssh/mod.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/ssh/mod.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/deployment.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/redeploy.rs), [cdn.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/cdn.rs), [waf.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/waf.rs)
+- CLI source: [status.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/status.rs), [service.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/service.rs), [logs.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/logs.rs), [metrics.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/metrics.rs), [ssh/mod.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/ssh/mod.rs), [deployment.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/deployment.rs), [redeploy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/redeploy.rs), [cdn.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/cdn.rs), [waf.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/waf.rs)
+- Authentication and CI recovery (v5.49.1): [client.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/client.rs), [up.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/up.rs)

--- a/plugins/railway/skills/use-railway/references/request.md
+++ b/plugins/railway/skills/use-railway/references/request.md
@@ -1,6 +1,6 @@
 # Request
 
-Official documentation and community endpoints. GraphQL operations for things the CLI doesn't expose.
+Official documentation and community endpoints. GraphQL operations without a dedicated CLI command or MCP tool.
 
 ## Official documentation
 
@@ -83,28 +83,36 @@ Thread URLs follow the format: `https://station.railway.com/{topic_slug}/{thread
 Community threads are anecdotal. Always pair with official docs when the answer informs an operational decision.
 
 
-## GraphQL helper
+## GraphQL with the CLI
 
-All GraphQL operations use the API helper script, which handles authentication automatically:
+Use `railway api` (CLI 5.28+) for API operations that dedicated commands and MCP tools cannot express. It uses the CLI's configured authentication and supports normal token refresh. Inspect the live schema before guessing fields or input shapes:
 
 ```bash
-scripts/railway-api.sh '<query>' '<variables-json>'
+railway api search projectUpdate --kind mutation
+railway api describe ProjectUpdateInput
+railway api describe Mutation.projectUpdate
+railway api schema --compact
+railway api '<query>' --variables '{"id":"<resource-id>"}'
+railway api --file query.graphql --variables @variables.json
+railway api --file query.graphql --raw-var id=<resource-id> --var enabled=true
 ```
 
-The script reads the API token from `~/.railway/config.json` and sends requests to `https://backboard.railway.com/graphql/v2`.
+`--var` parses JSON values when possible; `--raw-var` keeps strings. Queries can also come from stdin, with variables provided separately. Use `--operation-name` for documents containing multiple operations. Output is JSON by default; `--compact` changes formatting and there is no `--json` flag. HTTP errors and GraphQL `errors` fail the command; do not add `--allow-errors` when deciding whether a mutation succeeded. Query resource state before retrying an uncertain mutation.
+
+For an older CLI that cannot be upgraded, the bundled `scripts/railway-api.sh '<query>' '<variables-json>'` remains a compatibility fallback. It reads `user.token` from `~/.railway/config.json`; it does not implement the CLI's environment-token selection or OAuth refresh. It expects query first and variables second, not a query on stdin, and callers must inspect its response for GraphQL errors. Keep the skill telemetry prefix on `railway api` calls just like other CLI calls.
 
 For the full API schema, see: https://docs.railway.com/api/llms-docs.md
 
 ## Project mutations
 
-The CLI doesn't expose project setting updates (rename, PR deploys, visibility). Use GraphQL:
+There is no dedicated project command for these setting updates (rename, PR deploys, visibility). Use GraphQL:
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'mutation updateProject($id: String!, $input: ProjectUpdateInput!) {
     projectUpdate(id: $id, input: $input) { id name isPublic prDeploys botPrEnvironments }
   }' \
-  '{"id":"<project-id>","input":{"name":"new-name","prDeploys":true}}'
+  --variables '{"id":"<project-id>","input":{"name":"new-name","prDeploys":true}}'
 ```
 
 Common `ProjectUpdateInput` fields: `name`, `isPublic`, `prDeploys`, `botPrEnvironments`.
@@ -112,14 +120,14 @@ Common `ProjectUpdateInput` fields: `name`, `isPublic`, `prDeploys`, `botPrEnvir
 
 ## Service mutations
 
-The CLI can create services (`railway add`) but cannot rename them or change icons. Use GraphQL:
+Use `railway add` to create services and GraphQL to rename them or change icons:
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'mutation updateService($id: String!, $input: ServiceUpdateInput!) {
     serviceUpdate(id: $id, input: $input) { id name icon }
   }' \
-  '{"id":"<service-id>","input":{"name":"new-name"}}'
+  --variables '{"id":"<service-id>","input":{"name":"new-name"}}'
 ```
 
 `ServiceUpdateInput` fields: `name`, `icon` (image URL, animated GIF, or devicons URL like `https://devicons.railway.app/postgres`).
@@ -132,11 +140,11 @@ Get the service ID from `railway service list --json`.
 Prefer `railway add` for most cases. Use GraphQL for programmatic or advanced use:
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'mutation createService($input: ServiceCreateInput!) {
     serviceCreate(input: $input) { id name }
   }' \
-  '{"input":{"projectId":"<project-id>","name":"my-service","source":{"image":"nginx:latest"}}}'
+  --variables '{"input":{"projectId":"<project-id>","name":"my-service","source":{"image":"nginx:latest"}}}'
 ```
 
 `ServiceCreateInput` fields:
@@ -158,13 +166,13 @@ After creating a service via GraphQL, configure it with a JSON config patch incl
 Use `railway metrics` for routine metric checks. Use GraphQL only when you need custom measurements, grouping, sample rates, or averaging windows that the CLI doesn't expose.
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'query metrics($environmentId: String!, $serviceId: String, $startDate: DateTime!, $endDate: DateTime, $sampleRateSeconds: Int, $averagingWindowSeconds: Int, $groupBy: [MetricTag!], $measurements: [MetricMeasurement!]!) {
     metrics(environmentId: $environmentId, serviceId: $serviceId, startDate: $startDate, endDate: $endDate, sampleRateSeconds: $sampleRateSeconds, averagingWindowSeconds: $averagingWindowSeconds, groupBy: $groupBy, measurements: $measurements) {
       measurement tags { serviceId deploymentId region } values { ts value }
     }
   }' \
-  '{"environmentId":"<env-id>","serviceId":"<service-id>","startDate":"2026-02-19T00:00:00Z","measurements":["CPU_USAGE","MEMORY_USAGE_GB"]}'
+  --variables '{"environmentId":"<env-id>","serviceId":"<service-id>","startDate":"2026-02-19T00:00:00Z","measurements":["CPU_USAGE","MEMORY_USAGE_GB"]}'
 ```
 
 Available `MetricMeasurement` values: `CPU_USAGE`, `CPU_LIMIT`, `MEMORY_USAGE_GB`, `MEMORY_LIMIT_GB`, `NETWORK_RX_GB`, `NETWORK_TX_GB`, `DISK_USAGE_GB`, `EPHEMERAL_DISK_USAGE_GB`, `BACKUP_USAGE_GB`.
@@ -190,13 +198,13 @@ The CLI search command doesn't require authentication and supports pagination wi
 Use GraphQL only when the CLI output isn't enough for the workflow:
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'query templates($query: String!, $verified: Boolean, $recommended: Boolean) {
     templates(query: $query, verified: $verified, recommended: $recommended) {
       edges { node { code name description category } }
     }
   }' \
-  '{"query":"redis","verified":true}'
+  --variables '{"query":"redis","verified":true}'
 ```
 
 | Parameter | Type | Description |
@@ -230,21 +238,21 @@ For deploying into a specific environment or tracking the workflow, use the two-
 **Step 1**: Fetch the template config:
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'query template($code: String!) {
     template(code: $code) { id serializedConfig }
   }' \
-  '{"code":"postgres"}'
+  --variables '{"code":"postgres"}'
 ```
 
 **Step 2**: Deploy with `templateDeployV2`:
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'mutation deploy($input: TemplateDeployV2Input!) {
     templateDeployV2(input: $input) { projectId workflowId }
   }' \
-  '{"input":{
+  --variables '{"input":{
     "templateId":"<id-from-step-1>",
     "serializedConfig":<config-object-from-step-1>,
     "projectId":"<project-id>",
@@ -253,10 +261,10 @@ scripts/railway-api.sh \
   }}'
 ```
 
-`serializedConfig` is the raw JSON object from the template query, not a string. Get `workspaceId` via `scripts/railway-api.sh 'query { project(id: "<project-id>") { workspaceId } }' '{}'`.
+`serializedConfig` is the raw JSON object from the template query, not a string. Get `workspaceId` via `railway api 'query { project(id: "<project-id>") { workspaceId } }'`.
 
 
 ## Validated against
 
 - Docs: [api docs](https://docs.railway.com/api/llms-docs.md), [agents.md](https://docs.railway.com/agents), [community.md](https://docs.railway.com/community), [cli/docs.md](https://docs.railway.com/cli/docs), [templates.md](https://docs.railway.com/cli/templates), [metrics.md](https://docs.railway.com/cli/metrics)
-- CLI source: [docs.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/docs.rs), [templates.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/templates.rs), [metrics.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/metrics.rs)
+- CLI source: [api.rs (v5.49.1)](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/api.rs), [client.rs (v5.49.1)](https://github.com/railwayapp/cli/blob/v5.49.1/src/client.rs), [docs.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/docs.rs), [templates.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/templates.rs), [metrics.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/metrics.rs)

--- a/plugins/railway/skills/use-railway/references/request.md
+++ b/plugins/railway/skills/use-railway/references/request.md
@@ -99,7 +99,7 @@ railway api --file query.graphql --raw-var id=<resource-id> --var enabled=true
 
 `--var` parses JSON values when possible; `--raw-var` keeps strings. Queries can also come from stdin, with variables provided separately. Use `--operation-name` for documents containing multiple operations. Output is JSON by default; `--compact` changes formatting and there is no `--json` flag. HTTP errors and GraphQL `errors` fail the command; do not add `--allow-errors` when deciding whether a mutation succeeded. Query resource state before retrying an uncertain mutation.
 
-For an older CLI that cannot be upgraded, the bundled `scripts/railway-api.sh '<query>' '<variables-json>'` remains a compatibility fallback. It reads `user.token` from `~/.railway/config.json`; it does not implement the CLI's environment-token selection or OAuth refresh. It expects query first and variables second, not a query on stdin, and callers must inspect its response for GraphQL errors. Keep the skill telemetry prefix on `railway api` calls just like other CLI calls.
+For an older CLI that cannot be upgraded, the bundled `scripts/railway-api.sh '<query>' '<variables-json>'` remains a compatibility fallback. The database analysis scripts (`dal.py`, `analyze-postgres.py`) still call this helper directly, so it must stay in the plugin even when agents use `railway api`. It reads `user.token` from `~/.railway/config.json`; it does not implement the CLI's environment-token selection or OAuth refresh. It expects query first and variables second, not a query on stdin, and callers must inspect its response for GraphQL errors. Keep the skill telemetry prefix on `railway api` calls just like other CLI calls.
 
 For the full API schema, see: https://docs.railway.com/api/llms-docs.md
 

--- a/plugins/railway/skills/use-railway/references/setup.md
+++ b/plugins/railway/skills/use-railway/references/setup.md
@@ -59,14 +59,14 @@ railway init --name <project-name> --workspace <workspace-id-or-name>
 
 ### Update project settings
 
-Settings like project name, PR deploys, and visibility aren't exposed through the CLI. Use the GraphQL API helper (see [request.md](request.md)):
+Settings like project name, PR deploys, and visibility have no dedicated CLI command. Use `railway api` (see [request.md](request.md)):
 
 ```bash
-scripts/railway-api.sh \
+railway api \
   'mutation updateProject($id: String!, $input: ProjectUpdateInput!) {
     projectUpdate(id: $id, input: $input) { id name isPublic prDeploys }
   }' \
-  '{"id":"<project-id>","input":{"name":"new-name","prDeploys":true}}'
+  --variables '{"id":"<project-id>","input":{"name":"new-name","prDeploys":true}}'
 ```
 
 ## Services
@@ -140,7 +140,17 @@ railway connect <database-service> --ssh
 railway connect <database-service> --no-ssh
 ```
 
-The local database client must be installed. By default, `connect` uses a public TCP proxy when one exists and falls back to an SSH tunnel when no public proxy URL is available. Use `--ssh` to force the tunnel path, or `--no-ssh` to require a public TCP proxy.
+The local database client must be installed for a shell. By default, `connect` uses a public TCP proxy when one exists and falls back to an SSH tunnel when no public proxy URL is available. Use `--ssh` to force the tunnel path, or `--no-ssh` to require a public TCP proxy.
+
+For TablePlus, DBeaver, pgAdmin, or another GUI, CLI 5.27+ can hold a private tunnel open without starting or requiring a local database CLI:
+
+```bash
+railway connect <database-service> --tunnel-only --port 15432 --project <project-id> --environment production
+```
+
+`--tunnel-only` implies SSH and conflicts with `--no-ssh`. Omit `--port` to choose an available ephemeral port. Use the printed local connection details in the GUI; they include credentials, so do not echo them into a report. Keep the process running while the GUI is connected and stop it when finished. With `--project`, always supply `--environment`.
+
+For backups, PITR, HA conversion/scaling, or connection pooling, load [databases.md](databases.md).
 
 ### Delete a service
 
@@ -361,4 +371,5 @@ When creating projects, Railway uses the default workspace unless `--workspace` 
 ## Validated against
 
 - Docs: [cli.md](https://docs.railway.com/cli), [init.md](https://docs.railway.com/cli/init), [add.md](https://docs.railway.com/cli/add), [link.md](https://docs.railway.com/cli/link), [project.md](https://docs.railway.com/cli/project), [service.md](https://docs.railway.com/cli/service), [connect.md](https://docs.railway.com/cli/connect), [templates.md](https://docs.railway.com/cli/templates), [list.md](https://docs.railway.com/cli/list), [whoami.md](https://docs.railway.com/cli/whoami)
-- CLI source: [init.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/init.rs), [add.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/add.rs), [project.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/project.rs), [service.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/service.rs), [connect.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/connect.rs), [templates.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/templates.rs), [list.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/list.rs), [bucket.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/bucket.rs)
+- CLI source: [init.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/init.rs), [add.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/add.rs), [project.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/project.rs), [service.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/service.rs), [connect.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/connect.rs), [templates.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/templates.rs), [list.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/list.rs), [bucket.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/bucket.rs)
+- API command: [api.rs (v5.49.1)](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/api.rs)

--- a/plugins/railway/skills/use-railway/references/usage.md
+++ b/plugins/railway/skills/use-railway/references/usage.md
@@ -1,0 +1,52 @@
+# Usage and spending limits
+
+Use `railway usage` (CLI 5.25+) to explain billed resource usage and project/service costs. CLI 5.26+ adds explicit workspace versus Railway Agent spending-limit targets. For live CPU, memory, network, or latency measurements, use [operate.md](operate.md).
+
+## Read usage
+
+Resolve the workspace from the user's request or `railway whoami --json`. These commands are workspace-scoped, not scoped by the current service or environment:
+
+```bash
+railway usage --workspace <workspace> --json
+railway usage --workspace <workspace> --period previous --json
+railway usage --workspace <workspace> --period 2026-08 --json
+railway usage projects --workspace <workspace> --json
+railway usage projects --workspace <workspace> --limit 10 --json
+railway usage projects --workspace <workspace> --project <project> --period current --json
+```
+
+`--period` accepts `current`, `previous`, or `YYYY-MM` and applies only to summaries and project breakdowns. Report the returned billing-period dates with cost comparisons. `projects --project` returns a service breakdown and cannot be combined with `--limit`. Human output defaults to the top 25 projects; JSON returns all unless limited. Deleted resources can still contribute to the period's costs.
+
+Distinguish current usage from an estimated end-of-period bill. Estimates can be unavailable and are not final invoices. Use the returned cost fields rather than recomputing them from hardcoded prices; do not treat missing values as zero.
+
+## Inspect and change limits
+
+```bash
+railway usage limit status --workspace <workspace> --target workspace --json
+railway usage limit status --workspace <workspace> --target agent --json
+railway usage limit set --workspace <workspace> --target workspace --soft 75 --hard 125 --json
+railway usage limit set --workspace <workspace> --target agent --soft 7.50 --hard 20 --json
+```
+
+Read the target's existing limits before changing them. `set` requires `--target`; `status` without a target reports both. `workspace` controls resource/compute usage; `agent` controls Railway Agent usage. Do not infer that the agent target caps cloud VM compute costs or another coding harness's provider bill.
+
+Soft limits are email alerts; hard limits enforce a spending cap and can interrupt the corresponding service. Set only the target and amounts the user requested. Inputs are dollars: workspace limits require whole dollars; agent limits accept cents. Omitted fields preserve existing values, but setting an agent soft limit without any existing hard limit requires supplying a hard limit too. Follow CLI validation for supported ranges.
+
+```bash
+railway usage limit update --workspace <workspace> --soft 75 --json
+railway usage limit remove --workspace <workspace> --yes --json
+```
+
+`update` and `remove` are workspace compute-limit operations, not generic agent-target operations. Removing limits removes the spending protection; `--yes` skips confirmation and belongs only on an authorized removal. `--period` is invalid on all limit commands. After any mutation, reread `limit status` for the same workspace and target and report the resulting limits.
+
+## Troubleshoot
+
+- **Wrong totals**: check the workspace, returned billing-period boundaries, selected project, and whether deleted resources contributed.
+- **Missing estimate**: report actual usage and the unavailable estimate separately.
+- **Limit command rejected**: check target, dollar precision, required hard limit, and CLI version; do not retry with a different spending target.
+- **Permission denied**: verify billing access to the workspace; project access alone does not establish permission to change spending limits.
+
+## Validated against
+
+- Docs: [Usage CLI](https://docs.railway.com/cli/usage)
+- CLI source (v5.49.1): [usage.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/usage.rs)


### PR DESCRIPTION
The skill still used outdated feature-flag and MCP syntax, recommended legacy Config as Code for some projects, and omitted recent CLI workflows. Update the guidance through CLI v5.49.1 and bump all four plugin manifests and skill telemetry to 1.4.0.

- Correct feature-flag targeting and rollout commands, distinguish hosted MCP proxy/editor OAuth/local server modes, and use native `railway api` with schema discovery and error handling.
- Cover TypeScript/Python/Go IaC, legacy migration, secret-preserving imports, and saved plans. Document the remaining Python/Go migration limitations so agents check settings before applying.
- Add focused references for database recovery/HA/pooling, cloud agents, and usage/spending limits; route them from the main skill.
- Update deployment verification, DNS logs, GUI database tunnels, variable editing/sealed values, and OAuth troubleshooting.

Validation completed locally:

- 32 hook tests passed; ShellCheck passed for all three shell scripts.
- Skill validator passed; JSON parsing, four-manifest version alignment, telemetry, MCP config consistency, local reference links, and Python compilation passed.
- Checked 392 documented command examples against 190 help surfaces from the released v5.49.1 binary; reviewed changed behavior against CLI source and official docs. No live infrastructure mutations were used for validation.
- `git diff --check` passed.
