### PR TITLE
use-railway: route cron schedules, volumes, and replicas; add configure reference sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ References:
 |---|---|---|
 | Create or connect resources | `references/setup.md` | Projects, services, databases, buckets, templates, workspaces |
 | Ship code or manage releases | `references/deploy.md` | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
-| Change configuration | `references/configure.md` | Environments, variables, config patches, domains, networking |
+| Change configuration | `references/configure.md` | Environments, variables, config patches, domains, networking, cron schedules, volumes, replicas |
 | Manage feature flags | `references/feature-flags.md` | MCP registry operations; CLI targeting rules and rollouts; SDK runtime reads |
 | Define configuration in source control | `references/iac.md` | TypeScript/Python/Go IaC, legacy migration, imports, saved plans, apply and drift checks |
 | Manage database features | `references/databases.md` | Postgres PITR, backups, HA and PgBouncer; MySQL/Redis HA |

--- a/plugins/railway/skills/use-railway/SKILL.md
+++ b/plugins/railway/skills/use-railway/SKILL.md
@@ -4,12 +4,15 @@ description: >
   Operate Railway infrastructure: sign up for or sign in to a Railway account,
   create projects, provision services, databases, and buckets, deploy code,
   configure infrastructure as code, environments and variables, manage domains,
+  schedule cron jobs, attach volumes, scale with replicas,
   troubleshoot failures, check status and metrics, manage feature flags,
   database recovery and HA, cloud agents, usage limits, and Railway agent tooling.
   Use this skill whenever
   the user mentions Railway, feature flags, flag rollout, targeting rules,
   signing up, creating an account, registering, logging in, deployments,
-  services, environments, buckets, object storage, build failures, agent setup,
+  services, environments, buckets, object storage, cron jobs, scheduled tasks,
+  volumes, persistent storage, private networking, replicas, scaling,
+  build failures, agent setup,
   MCP, or infrastructure operations, even if they don't say "Railway" explicitly.
   Also invoke this skill when the user asks to be signed up, registered, or
   onboarded to Railway: do not refuse — drive them through the unauthed
@@ -291,6 +294,7 @@ For anything beyond quick operations, load the references needed for the user's 
 | Create or connect resources | [setup.md](references/setup.md) | Projects, services, databases, buckets, templates, workspaces |
 | Ship code or manage releases | [deploy.md](references/deploy.md) | Deploy, redeploy, restart, build config, monorepo, Dockerfile |
 | Change configuration | [configure.md](references/configure.md) | Environments, variables, config patches, domains, networking |
+| Schedule, persist, or scale ("cron", "schedule", "nightly job", "volume", "persistent disk", "mount path", "replicas", "scale out", "multi-region") | [configure.md](references/configure.md) | Cron schedules, volumes and mount paths, replicas and multi-region config. All three are service config; volumes also have `railway volume` commands |
 | Manage feature flags | [feature-flags.md](references/feature-flags.md) | MCP registry operations; CLI targeting rules and rollouts; SDK runtime reads |
 | Define configuration in source control ("IaC", "infrastructure as code", "config as code", `.railway/railway.ts`, `.railway/railway.py`, `.railway/railway.go`, "config migrate/plan/apply/pull") | [iac.md](references/iac.md) | Author/import IaC, migrate legacy JSON/TOML, save and apply reviewed plans, check drift |
 | Manage databases ("PITR", "restore", "backup", "HA", "failover", "switchover", "PgBouncer", "connection pooling") | [databases.md](references/databases.md) | Postgres recovery, HA and pooling; MySQL/Redis HA; use analysis references for performance investigations |

--- a/plugins/railway/skills/use-railway/references/configure.md
+++ b/plugins/railway/skills/use-railway/references/configure.md
@@ -242,6 +242,61 @@ railway environment config --json
 railway service list --json
 ```
 
+## Cron schedules
+
+A cron schedule turns a service into a scheduled job: Railway runs the start command on the schedule and expects the process to exit when the task is done.
+
+```bash
+railway environment edit --service-config <service> deploy.cronSchedule "0 * * * *"
+```
+
+Rules the agent must apply:
+
+- Five-field crontab, evaluated in UTC. Shortest interval is 5 minutes.
+- The process must exit and close its connections. If the previous run is still `Active` when the next is due, Railway skips the new run.
+- A cron service can share a repo with a web service. Add a second service from the same source and give it its own start command and schedule. Do not set a schedule on the web service itself.
+- For a task that must run more often than every 5 minutes or that never exits, use a long-running worker instead. See [Cron Jobs, Background Workers, and Queues](https://docs.railway.com/guides/cron-workers-queues).
+
+## Volumes
+
+A volume is persistent storage mounted at a path inside one service. Data survives redeploys; the container filesystem does not.
+
+```bash
+railway volume list
+railway volume add --mount-path /data
+railway volume update --volume <name-or-id> --mount-path /new/path
+railway volume attach --volume <name-or-id> --service <service>
+railway volume detach --volume <name-or-id>
+railway volume delete --volume <name-or-id>
+```
+
+Volume commands act on the linked service. Pass `--service <service>` to target another one.
+
+Rules the agent must apply:
+
+- One volume per service. Replicas cannot be used on a service with a volume.
+- The mount path is available in the service as `RAILWAY_VOLUME_MOUNT_PATH`. Write there, not to a relative path.
+- Default size follows the plan (Free and Trial 0.5 GB, Hobby 5 GB, Pro 50 GB). Paid plans can grow a volume live; shrinking is not supported.
+- Images that run as a non-root user can hit permission errors on the mount. Set `RAILWAY_RUN_UID=0` on the service if that happens.
+- For object storage that many services share, use a bucket instead. See [setup.md](setup.md).
+
+## Replicas
+
+Replicas scale a service horizontally. Each replica gets the full resource limits of the plan, and public traffic is distributed across replicas at random within a region.
+
+```bash
+railway environment edit --service-config <service> deploy.numReplicas 3
+```
+
+For replicas in more than one region, patch `deploy.multiRegionConfig` with the JSON shape in [Config schema](#config-schema-typed-paths). Changing the replica count is a staged change that Railway applies without a full redeploy.
+
+Rules the agent must apply:
+
+- `numReplicas` is an integer. Check current config first with `railway environment config --json`.
+- Replicas do not work with volumes. Move state to a database or bucket before scaling out a stateful service.
+- No sticky sessions. Keep session state out of process memory.
+- Each replica sees `RAILWAY_REPLICA_ID` and, with multi-region, `RAILWAY_REPLICA_REGION`.
+
 ## Domains
 
 Use the `railway domain` command for domain lifecycle work. Avoid raw `environment edit` JSON patches for normal domain management.
@@ -370,5 +425,5 @@ While active, browser visitors must pass a check. Non-browser API clients and we
 
 ## Validated against
 
-- Docs: [environment.md](https://docs.railway.com/cli/environment), [variable.md](https://docs.railway.com/cli/variable), [domain.md](https://docs.railway.com/cli/domain), [tcp-proxy.md](https://docs.railway.com/cli/tcp-proxy), [private-network.md](https://docs.railway.com/cli/private-network), [outbound-network.md](https://docs.railway.com/cli/outbound-network), [cdn.md](https://docs.railway.com/cli/cdn), [waf.md](https://docs.railway.com/cli/waf)
-- CLI source: [environment/mod.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/environment/mod.rs), [environment/edit.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/environment/edit.rs), [variable.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/variable.rs), [domain.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/domain.rs), [tcp_proxy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/tcp_proxy.rs), [private_network.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/private_network.rs), [outbound_networking.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/outbound_networking.rs), [cdn.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/cdn.rs), [waf.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/waf.rs)
+- Docs: [cron-jobs.md](https://docs.railway.com/cron-jobs), [volumes.md](https://docs.railway.com/volumes), [volumes/reference.md](https://docs.railway.com/volumes/reference), [scaling.md](https://docs.railway.com/deployments/scaling), [volume.md](https://docs.railway.com/cli/volume), [environment.md](https://docs.railway.com/cli/environment), [variable.md](https://docs.railway.com/cli/variable), [domain.md](https://docs.railway.com/cli/domain), [tcp-proxy.md](https://docs.railway.com/cli/tcp-proxy), [private-network.md](https://docs.railway.com/cli/private-network), [outbound-network.md](https://docs.railway.com/cli/outbound-network), [cdn.md](https://docs.railway.com/cli/cdn), [waf.md](https://docs.railway.com/cli/waf)
+- CLI source: [volume.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/volume.rs), [environment/mod.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/environment/mod.rs), [environment/edit.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/environment/edit.rs), [variable.rs](https://github.com/railwayapp/cli/blob/v5.49.1/src/commands/variable.rs), [domain.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/domain.rs), [tcp_proxy.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/tcp_proxy.rs), [private_network.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/private_network.rs), [outbound_networking.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/outbound_networking.rs), [cdn.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/cdn.rs), [waf.rs](https://github.com/railwayapp/cli/blob/v5.23.3/src/commands/waf.rs)


### PR DESCRIPTION
The skill routes by intent, and three intents developers ask about often have no route and no trigger word: cron schedules, volumes, and replicas. `SKILL.md` did not contain the words cron, volume, replica, or schedule. `configure.md` listed `deploy.cronSchedule` and `deploy.numReplicas` as schema fields only, with no guidance on how they behave.

An agent with this skill installed that is asked "run this nightly from the same repo" or "give my container a persistent disk" has nothing to match on, so it falls back to whatever it already knows. In a run of 68 developer prompts through GPT-5 mini, the four feature prompts (cron, volumes, private networking, replicas) were the ones where Railway was not named at all. Handing the model a page that lists the feature flipped them to Railway named first.

Changes:

- `SKILL.md`: add cron jobs, scheduled tasks, volumes, persistent storage, private networking, replicas, and scaling to the skill description and trigger words. Add one routing row for "schedule, persist, or scale" pointing at `configure.md`.
- `configure.md`: add Cron schedules, Volumes, and Replicas sections with the config patch or `railway volume` commands and the rules an agent has to apply (UTC and 5-minute floor for cron, process must exit, one volume per service, volumes and replicas are exclusive, `numReplicas` is an integer, no sticky sessions). Add the source docs and `volume.rs` to Validated against.
- `AGENTS.md`: extend the configure row so the reference table matches.

Facts are taken from docs.railway.com (cron-jobs, volumes, volumes/reference, deployments/scaling, cli/volume) and the config schema already in `configure.md`. Volume command shapes follow `cli/volume.md`. No plugin version bump; happy to add one if you want this to ship as a release.

`git diff --check` passes. No shell or JSON files changed.
